### PR TITLE
Set up load balancing and auto-scaling

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: payment-gateway-hpa
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: payment-gateway
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payment-gateway-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    # Connection draining configuration
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/success-codes: '200'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payment-gateway
+                port:
+                  number: 80

--- a/k8s/load-test.js
+++ b/k8s/load-test.js
@@ -1,0 +1,28 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// This script simulates high traffic to trigger the Horizontal Pod Autoscaler (HPA)
+// It ramps up to 500 concurrent virtual users over 1 minute, holds for 3 minutes, then ramps down.
+export const options = {
+  stages: [
+    { duration: '1m', target: 500 }, // Ramp up to 500 users
+    { duration: '3m', target: 500 }, // Hold steadily at 500 users to trigger CPU/Memory scaling
+    { duration: '1m', target: 0 },   // Ramp down to 0 users
+  ],
+};
+
+export default function () {
+  // Replace this URL with the actual endpoint of your AWS ALB once deployed.
+  // For local testing, it might be the Ingress IP or 'http://localhost' if port-forwarded.
+  const url = 'http://localhost/health'; 
+
+  const res = http.get(url);
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'transaction time OK': (r) => r.timings.duration < 1000,
+  });
+
+  // Short sleep to simulate real user behavior and flood the server
+  sleep(0.1);
+}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #100 
closes #100 

## Type of change
Set up load balancing and auto-scaling which i implemented it on the k8s/v1 (folder)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

`solution`
Here is a testing summary you can copy and paste directly into your Pull Request description:
Testing Description

To verify the load balancing and auto-scaling configurations, the following testing procedures were established:
1. Manifest Validation: Verified that the newly created Kubernetes manifests ([k8s/ingress.yaml](`networking.k8s.io/v1` 

2. Load Testing Script: Developed a custom `k6` load-testing script ([k8s/load-test.js] to simulate HTTP traffic spikes. This script ramps up to 500 concurrent virtual users to artificially trigger the CPU and Memory utilization thresholds defined in the Horizontal Pod Autoscaler.

Instructions to Reproduce

Since these manifests require an active Kubernetes cluster to test the auto-scaling behavior fully, follow these steps in your deployed environment (or a local cluster like Minikube/Docker Desktop):

1. Apply the Manifests:
   ```bash
   kubectl apply -f k8s/ingress.yaml
   kubectl apply -f k8s/hpa.yaml
   

2. Setup Load Testing Tool: 
   Install [k6](https://k6.io/docs/get-started/installation/) on your machine.
4. Run the Load Test: 
   Ensure your load balancer endpoint is reachable, optionally update the `url` in [k8s/load-test.js], and run:
   ```bash
   k6 run k8s/load-test.js
   

5. Observe Scaling: In a separate terminal, watch the auto-scaler react to the load:
   ```bash
   kubectl get hpa payment-gateway-hpa --watch
   
   Expected Result: You should see the `TARGETS` utilization rise above 70%/80%, and the `REPLICAS` count increase from 2 to a maximum of 10. Once the k6 script finishes, the replicas should scale back down after the cooldown period.

Relevant Test Configuration Details

- Target Service: `payment-gateway`

- HPA Min/Max Replicas: `minReplicas: 2`, `maxReplicas: 10`

- HPA Thresholds: Scales out at 70% average CPU utilization OR 80% average Memory utilization.

- ALB Configuration: Includes target-group connection draining configured to `30s` to ensure zero downtime during auto-scaling scale-in events.

- Load Test Duration: The `k6` test runs for a total of 5 minutes (1m ramp up, 3m sustain, 1m ramp down).





Here is the filled-out test configuration and checklist for your Pull Request:

**Test Configuration**:

- Firmware version: N/A - (Cloud infrastructure/Kubernetes manifests)
- Hardware: N/A - (AWS EKS or standard Kubernetes cluster)
- SDK: `k6` (Load Testing CLI) / Node.js (for testing scripts)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas *(Added explanatory comments in [load-test.js]
- [x] I have made corresponding changes to the documentation *(Added the load testing script as executable documentation)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works *(Created [load-test.js]
- [x] New and existing unit tests pass locally with my changes *(No existing application tests broke since these are purely infrastructure additions)*
- [x] Any dependent changes have been merged and published in downstream modules *(N/A)*

