### PR TITLE
docs: add all missing environment variables to .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,16 +7,48 @@ JWT_SECRET=your-super-secret-jwt-key-change-in-production
 # Stellar Network
 STELLAR_NETWORK=TESTNET
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_NETWORK_URL=https://soroban-testnet.stellar.org
+
+# Stellar Storage
+STELLAR_STORAGE_SECRET=replace-with-stellar-storage-secret
+
+# Stellar Deposit
+STELLAR_DEPOSIT_ADDRESS=GDEPOSITADDRESSXXXXXXX
+
+# Soroban RPC
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Issuer
+ISSUER_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Mirror Asset
+MIRROR_ASSET_CONTRACT_ID=CCONTRACTIDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # Treasury
 TREASURY_WALLET_ADDRESS=GDTREASURYADDRESSXXXXXX
 SUPPORTED_ASSETS=USDC,ARS
 
+# Bitcoin
+BTC_XPUB=xpubXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+BTC_API_URL=https://blockstream.info/testnet/api
+
+# Ethereum
+ETH_XPUB=xpubXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+ETH_RPC_URL=https://sepolia.infura.io/v3/YOUR_INFURA_KEY
+
+# Transaction Monitor
+MONITOR_POLL_INTERVAL_MS=30000
+
 # Database (for when implemented)
-DATABASE_URL=postgresql://user:password@localhost:5432/stellar_pay
+DATABASE_URL=postgresql://user:***@localhost:5432/stellar_pay
 
 # Redis (for when implemented)
 REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Webhooks
+# Add any additional webhook configuration here
 
 # Audit Logging
 AUDIT_LOG_CHAIN_SECRET=replace-with-a-long-random-secret


### PR DESCRIPTION
## Summary

Cross-referenced every `process.env.X` usage in the codebase and added all 13 missing variables to `apps/api/.env.example`.

## Changes

Added the following environment variables with sensible defaults/placeholders:

| Variable | Used In | Description |
|----------|---------|-------------|
| `STELLAR_NETWORK_URL` | StellarService | Soroban RPC URL |
| `STELLAR_STORAGE_SECRET` | StellarService | Storage encryption secret |
| `STELLAR_DEPOSIT_ADDRESS` | DepositAddressService | Deposit address |
| `SOROBAN_RPC_URL` | Treasury stubs | Soroban RPC endpoint |
| `ISSUER_PUBLIC_KEY` | Treasury stubs | Stellar issuer public key |
| `MIRROR_ASSET_CONTRACT_ID` | Treasury stubs | Mirror asset contract |
| `BTC_XPUB` | DepositAddressService | Bitcoin extended public key |
| `BTC_API_URL` | DepositAddressService | Bitcoin API endpoint |
| `ETH_XPUB` | DepositAddressService | Ethereum extended public key |
| `ETH_RPC_URL` | DepositAddressService | Ethereum RPC endpoint |
| `MONITOR_POLL_INTERVAL_MS` | TransactionMonitorService | Poll interval (default 30s) |
| `REDIS_HOST` | WebhooksService | Redis hostname |
| `REDIS_PORT` | WebhooksService | Redis port |

## Testing

- [x] File is valid (no syntax errors)
- [x] All `process.env.X` references in codebase now have corresponding entries

## Related Issues

Fixes #182