### PR TITLE
Implement Redis rate-limiting storage

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { ApiKeysModule } from './api-keys/api-keys.module.js';
 import { AuditLogModule } from './audit-log/audit-log.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { ThrottlerRedisGuard } from './rate-limiter/guards/throttler-redis.guard';
+import { ThrottlerStorageRedisService } from './rate-limiter/throttler-storage-redis.service';
 import { TransactionsModule } from './transactions/transactions.module';
 import { WorkerModule } from './modules/worker/worker.module';
 import { WebhookModule } from './webhooks/webhook.module';
@@ -31,13 +32,13 @@ import { PaymentsModule } from './payments/payments.module';
         { name: 'short', ttl: 60000, limit: 100 },
         { name: 'long', ttl: 60000, limit: 1000 },
       ],
-      // TODO: Implement Redis storage when Redis service is available
-      // storage: new ThrottlerStorageRedisService(),
+      storage: new ThrottlerStorageRedisService(),
     }),
   ],
   controllers: [AppController],
   providers: [
     AppService,
+    ThrottlerStorageRedisService,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/apps/api/src/rate-limiter/throttler-storage-redis.service.ts
+++ b/apps/api/src/rate-limiter/throttler-storage-redis.service.ts
@@ -1,29 +1,44 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ThrottlerStorage } from '@nestjs/throttler';
+import Redis from 'ioredis';
 
 @Injectable()
 export class ThrottlerStorageRedisService implements ThrottlerStorage {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private client: any = null;
+  private readonly logger = new Logger(ThrottlerStorageRedisService.name);
+  private client: Redis | null = null;
 
-  private async getClient() {
+  private async getClient(): Promise<Redis | null> {
     if (this.client) return this.client;
 
-    // TODO: Inject Redis client when Redis service is implemented
-    // Example:
-    // if (!this.client) {
-    //   this.client = await createClient(process.env.REDIS_URL).connect();
-    // }
+    this.client = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: parseInt(process.env.REDIS_PORT || '6379', 10),
+      maxRetriesPerRequest: 3,
+      retryStrategy: (times) => Math.min(times * 100, 3000),
+      lazyConnect: true,
+    });
 
-    return null;
+    this.client.on('error', (err) => {
+      this.logger.error(`Redis connection error: ${err.message}`);
+    });
+
+    try {
+      await this.client.connect();
+    } catch (err) {
+      this.logger.error(`Failed to connect to Redis: ${(err as Error).message}`);
+      this.client = null;
+      return null;
+    }
+
+    return this.client;
   }
 
   async increment(
-    _key: string,
+    key: string,
     ttl: number,
-    _limit: number,
-    _blockDuration: number,
-    _throttlerName: string,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
   ) {
     const client = await this.getClient();
 
@@ -31,26 +46,32 @@ export class ThrottlerStorageRedisService implements ThrottlerStorage {
       return { totalHits: 1, timeToExpire: ttl, isBlocked: false, timeToBlockExpire: 0 };
     }
 
-    // TODO: Implement Redis storage
-    // Example:
-    // const redisKey = `throttler:${throttlerName}:${key}`;
-    // const multi = client.multi();
-    // multi.incr(redisKey);
-    // multi.ttl(redisKey);
-    // const [totalHits, timeToExpire] = await multi.exec();
-    //
-    // if (totalHits === 1) {
-    //   await client.expire(redisKey, Math.ceil(ttl / 1000));
-    // }
-    //
-    // const isBlocked = totalHits > limit;
-    // return {
-    //   totalHits,
-    //   timeToExpire: timeToExpire >= 0 ? timeToExpire * 1000 : ttl,
-    //   isBlocked,
-    //   timeToBlockExpire: isBlocked ? blockDuration : 0,
-    // };
+    const redisKey = `throttler:${throttlerName}:${key}`;
+    const multi = client.multi();
+    multi.incr(redisKey);
+    multi.ttl(redisKey);
+    const results = await multi.exec();
 
-    return { totalHits: 1, timeToExpire: ttl, isBlocked: false, timeToBlockExpire: 0 };
+    if (!results) {
+      return { totalHits: 1, timeToExpire: ttl, isBlocked: false, timeToBlockExpire: 0 };
+    }
+
+    const totalHits = results[0][1] as number;
+    let timeToExpire = results[1][1] as number;
+
+    if (totalHits === 1) {
+      await client.expire(redisKey, Math.ceil(ttl / 1000));
+      timeToExpire = Math.ceil(ttl / 1000);
+    }
+
+    timeToExpire = timeToExpire >= 0 ? timeToExpire * 1000 : ttl;
+
+    const isBlocked = totalHits > limit;
+    return {
+      totalHits,
+      timeToExpire,
+      isBlocked,
+      timeToBlockExpire: isBlocked ? blockDuration : 0,
+    };
   }
 }


### PR DESCRIPTION
## Summary
Wire up `ThrottlerStorageRedisService` with actual Redis pipeline commands using `ioredis`.

## Changes
- Implemented `increment()` using Redis `MULTI/EXEC` pipeline:
  - `INCR` the rate-limit key
  - `TTL` to get remaining time-to-live
  - `EXPIRE` to set expiry on first request
- Added Redis connection config via env vars (`REDIS_HOST`, `REDIS_PORT`) with fallback defaults
- Wired up `ThrottlerStorageRedisService` in `AppModule` as storage provider
- Graceful fallback when Redis is unavailable

## Path
- `apps/api/src/rate-limiter/throttler-storage-redis.service.ts`
- `apps/api/src/app.module.ts`

Closes #185