### PR TITLE
feat: add reusable password hashing utilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,6 +57,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
+    "@types/bcrypt": "^5.0.2",
     "@types/bip32": "^2.0.4",
     "@types/cron": "^2.4.3",
     "@types/express": "^5.0.0",

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
-import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
 import { RegisterMerchantDto } from './dto/register-merchant.dto';
 import { LoginMerchantDto } from './dto/login-merchant.dto';
+import { comparePassword, hashPassword } from './password.util';
 
 @Injectable()
 export class AuthService {
@@ -26,7 +26,7 @@ export class AuthService {
     const existing = await this.prisma.merchant.findUnique({ where: { email: dto.email } });
     if (existing) throw new BadRequestException('Email already in use');
 
-    const hash = await bcrypt.hash(dto.password, 12);
+    const hash = await hashPassword(dto.password);
 
     const merchant = await this.prisma.merchant.create({
       data: { email: dto.email, passwordHash: hash },
@@ -39,7 +39,7 @@ export class AuthService {
     const merchant = await this.prisma.merchant.findUnique({ where: { email: dto.email } });
     if (!merchant) throw new UnauthorizedException('Invalid credentials');
 
-    const ok = await bcrypt.compare(dto.password, merchant.passwordHash);
+    const ok = await comparePassword(dto.password, merchant.passwordHash);
     if (!ok) throw new UnauthorizedException('Invalid credentials');
 
     const payload = { merchant_id: merchant.id };

--- a/apps/api/src/auth/password.util.ts
+++ b/apps/api/src/auth/password.util.ts
@@ -1,0 +1,11 @@
+import * as bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 12;
+
+export function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, SALT_ROUNDS);
+}
+
+export function comparePassword(password: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(password, hash);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.0.1
         version: 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@nestjs/platform-express@11.1.27)
+      '@types/bcrypt':
+        specifier: ^5.0.2
+        version: 5.0.2
       '@types/bip32':
         specifier: ^2.0.4
         version: 2.0.4
@@ -5008,6 +5011,12 @@ packages:
         integrity: sha512-5VE8jtDlFx94IyopdhtkcZ/6oCSvpLS1yOcwkUgi9/zwL9LG99q4+nYv6N/HntPGqB9wcE6osxrtmErt75sjxA==,
       }
     deprecated: This is a stub types definition. bip32 provides its own type definitions, so you do not need this installed.
+
+  '@types/bcrypt@5.0.2':
+    resolution:
+      {
+        integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==,
+      }
 
   '@types/body-parser@1.19.6':
     resolution:
@@ -16371,6 +16380,10 @@ snapshots:
   '@types/bip32@2.0.4':
     dependencies:
       bip32: 4.0.0
+
+  '@types/bcrypt@5.0.2':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/body-parser@1.19.6':
     dependencies:


### PR DESCRIPTION
## Summary
- add reusable `hashPassword` and `comparePassword` helpers for API auth password handling
- keep password hashing at 12 salt rounds through the shared helper
- add `@types/bcrypt` to the API dev dependencies and lockfile

Closes #207

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec tsc --noEmit --module nodenext --moduleResolution nodenext --target ES2023 --esModuleInterop --skipLibCheck src/auth/password.util.ts` from `apps/api`

`pnpm --filter api build` is currently blocked by existing unrelated TypeScript errors on `main` in Prisma, Treasury, Webhooks, and existing auth JWT typing. This PR does not introduce those failures.