### PR TITLE
ci: auto-label new issues by content

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,46 @@
+name: Auto Label Issues
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    name: Label issue by content
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply matching labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const text = `${issue.title ?? ''}\n${issue.body ?? ''}`.toLowerCase();
+
+            const rules = [
+              { label: 'bug', keywords: ['bug', 'error', 'fail'] },
+              { label: 'enhancement', keywords: ['add', 'implement', 'feature'] },
+              { label: 'infrastructure', keywords: ['k8s', 'deploy', 'docker'] },
+              { label: 'testing', keywords: ['test', 'spec', 'coverage'] },
+            ];
+
+            const labels = rules
+              .filter((rule) => rule.keywords.some((keyword) => text.includes(keyword)))
+              .map((rule) => rule.label);
+
+            if (labels.length === 0) {
+              core.info('No auto-label rules matched this issue.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels,
+            });
+
+            core.info(`Applied labels: ${labels.join(', ')}`);


### PR DESCRIPTION
## Summary
- add an `issues` workflow for opened and reopened issues
- label issue content as `bug`, `enhancement`, `infrastructure`, and/or `testing` based on the requested keyword groups
- grant the workflow only `issues: write` and `contents: read`

Closes #287

## Validation
- Inspected `.github/workflows/auto-label.yml` locally
- `actionlint` is not installed in this environment, so local workflow linting was not available
- I did not open a test issue in the upstream repository; the workflow is limited to the requested trigger and can be verified by maintainers after merge