### PR TITLE
feat(payments-engine): add verifyPayment method and PaymentVerification interfaces

### DIFF
--- a/packages/payments-engine/dist/index.js
+++ b/packages/payments-engine/dist/index.js
@@ -30,7 +30,7 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // src/index.ts
 var index_exports = {};
 __export(index_exports, {
-  StellarService: () => StellarService
+  sendStellarPayment: () => sendStellarPayment
 });
 module.exports = __toCommonJS(index_exports);
 
@@ -74,14 +74,46 @@ var StellarService = class {
       throw error;
     }
   }
+  async verifyPayment(params) {
+    const { txHash, expectedDestination, expectedAmount, expectedAssetCode, expectedAssetIssuer } = params;
+    try {
+      const transaction = await this.server.transactions().transaction(txHash).call();
+      const operations = await this.server.operations().forTransaction(txHash).call();
+      const paymentOp = operations.records.find(
+        (op) => op.type === "payment" || op.type === "path_payment_strict_receive" || op.type === "path_payment_strict_send"
+      );
+      if (!paymentOp) {
+        return {
+          verified: false,
+          amount: "",
+          asset: "",
+          source: transaction.source_account,
+          memo: typeof transaction.memo === "string" ? transaction.memo : null,
+          timestamp: transaction.created_at
+        };
+      }
+      const paymentAssetCode = paymentOp.asset_code || "XLM";
+      const paymentAssetIssuer = paymentOp.asset_issuer;
+      const asset = paymentAssetCode + (paymentAssetIssuer ? `:${paymentAssetIssuer}` : "");
+      const destinationMatch = paymentOp.to === expectedDestination;
+      const amountMatch = paymentOp.amount === expectedAmount;
+      const assetCodeMatch = !expectedAssetCode || paymentAssetCode === expectedAssetCode;
+      const assetIssuerMatch = !expectedAssetIssuer || paymentAssetIssuer === expectedAssetIssuer;
+      return {
+        verified: destinationMatch && amountMatch && assetCodeMatch && assetIssuerMatch,
+        amount: paymentOp.amount,
+        asset,
+        source: paymentOp.from,
+        memo: typeof transaction.memo === "string" ? transaction.memo : null,
+        timestamp: transaction.created_at
+      };
+    } catch (error) {
+      console.error("Failed to verify payment:", error);
+      throw error;
+    }
+  }
   async createReceivePayment(params) {
-    const {
-      address,
-      timeoutMs = 3e4,
-      assetCode,
-      assetIssuer,
-      from
-    } = params;
+    const { address, timeoutMs = 3e4, assetCode, assetIssuer, from } = params;
     if (!StellarSdk.StrKey.isValidEd25519PublicKey(address)) {
       throw new Error(`Invalid Stellar address: ${address}`);
     }
@@ -145,7 +177,13 @@ var StellarService = class {
     });
   }
 };
+
+// src/index.ts
+var stellarService = new StellarService();
+async function sendStellarPayment(to, amount, asset) {
+  return stellarService.sendFunds(to, amount.toString(), asset === "XLM" ? void 0 : asset);
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
-  StellarService
+  sendStellarPayment
 });

--- a/packages/payments-engine/dist/index.mjs
+++ b/packages/payments-engine/dist/index.mjs
@@ -38,14 +38,46 @@ var StellarService = class {
       throw error;
     }
   }
+  async verifyPayment(params) {
+    const { txHash, expectedDestination, expectedAmount, expectedAssetCode, expectedAssetIssuer } = params;
+    try {
+      const transaction = await this.server.transactions().transaction(txHash).call();
+      const operations = await this.server.operations().forTransaction(txHash).call();
+      const paymentOp = operations.records.find(
+        (op) => op.type === "payment" || op.type === "path_payment_strict_receive" || op.type === "path_payment_strict_send"
+      );
+      if (!paymentOp) {
+        return {
+          verified: false,
+          amount: "",
+          asset: "",
+          source: transaction.source_account,
+          memo: typeof transaction.memo === "string" ? transaction.memo : null,
+          timestamp: transaction.created_at
+        };
+      }
+      const paymentAssetCode = paymentOp.asset_code || "XLM";
+      const paymentAssetIssuer = paymentOp.asset_issuer;
+      const asset = paymentAssetCode + (paymentAssetIssuer ? `:${paymentAssetIssuer}` : "");
+      const destinationMatch = paymentOp.to === expectedDestination;
+      const amountMatch = paymentOp.amount === expectedAmount;
+      const assetCodeMatch = !expectedAssetCode || paymentAssetCode === expectedAssetCode;
+      const assetIssuerMatch = !expectedAssetIssuer || paymentAssetIssuer === expectedAssetIssuer;
+      return {
+        verified: destinationMatch && amountMatch && assetCodeMatch && assetIssuerMatch,
+        amount: paymentOp.amount,
+        asset,
+        source: paymentOp.from,
+        memo: typeof transaction.memo === "string" ? transaction.memo : null,
+        timestamp: transaction.created_at
+      };
+    } catch (error) {
+      console.error("Failed to verify payment:", error);
+      throw error;
+    }
+  }
   async createReceivePayment(params) {
-    const {
-      address,
-      timeoutMs = 3e4,
-      assetCode,
-      assetIssuer,
-      from
-    } = params;
+    const { address, timeoutMs = 3e4, assetCode, assetIssuer, from } = params;
     if (!StellarSdk.StrKey.isValidEd25519PublicKey(address)) {
       throw new Error(`Invalid Stellar address: ${address}`);
     }
@@ -109,6 +141,12 @@ var StellarService = class {
     });
   }
 };
+
+// src/index.ts
+var stellarService = new StellarService();
+async function sendStellarPayment(to, amount, asset) {
+  return stellarService.sendFunds(to, amount.toString(), asset === "XLM" ? void 0 : asset);
+}
 export {
-  StellarService
+  sendStellarPayment
 };

--- a/packages/payments-engine/src/stellar.service.ts
+++ b/packages/payments-engine/src/stellar.service.ts
@@ -19,6 +19,23 @@ export interface ReceivePaymentResult {
   createdAt: string;
 }
 
+export interface PaymentVerificationParams {
+  txHash: string;
+  expectedDestination: string;
+  expectedAmount: string;
+  expectedAssetCode?: string;
+  expectedAssetIssuer?: string;
+}
+
+export interface PaymentVerificationResult {
+  verified: boolean;
+  amount: string;
+  asset: string;
+  source: string;
+  memo?: string | null;
+  timestamp: string;
+}
+
 type IncomingPaymentRecord =
   | StellarSdk.Horizon.ServerApi.PaymentOperationRecord
   | StellarSdk.Horizon.ServerApi.PathPaymentOperationRecord
@@ -84,6 +101,56 @@ export class StellarService {
     } catch (error) {
       console.error('Stellar transaction failed:', error);
       throw error; // Rethrow to let the worker handle the failure state
+    }
+  }
+
+  async verifyPayment(params: PaymentVerificationParams): Promise<PaymentVerificationResult> {
+    const { txHash, expectedDestination, expectedAmount, expectedAssetCode, expectedAssetIssuer } =
+      params;
+
+    try {
+      const transaction = await this.server.transactions().transaction(txHash).call();
+
+      const operations = await this.server.operations().forTransaction(txHash).call();
+
+      const paymentOp = operations.records.find(
+        (op) =>
+          op.type === 'payment' ||
+          op.type === 'path_payment_strict_receive' ||
+          op.type === 'path_payment_strict_send',
+      ) as IncomingPaymentRecord | undefined;
+
+      if (!paymentOp) {
+        return {
+          verified: false,
+          amount: '',
+          asset: '',
+          source: transaction.source_account,
+          memo: typeof transaction.memo === 'string' ? transaction.memo : null,
+          timestamp: transaction.created_at,
+        };
+      }
+
+      const paymentAssetCode = paymentOp.asset_code || 'XLM';
+      const paymentAssetIssuer = paymentOp.asset_issuer;
+      const asset = paymentAssetCode + (paymentAssetIssuer ? `:${paymentAssetIssuer}` : '');
+
+      const destinationMatch = paymentOp.to === expectedDestination;
+      const amountMatch = paymentOp.amount === expectedAmount;
+      const assetCodeMatch = !expectedAssetCode || paymentAssetCode === expectedAssetCode;
+      const assetIssuerMatch = !expectedAssetIssuer || paymentAssetIssuer === expectedAssetIssuer;
+
+      return {
+        verified: destinationMatch && amountMatch && assetCodeMatch && assetIssuerMatch,
+        amount: paymentOp.amount,
+        asset,
+        source: paymentOp.from,
+        memo: typeof transaction.memo === 'string' ? transaction.memo : null,
+        timestamp: transaction.created_at,
+      };
+    } catch (error) {
+      console.error('Failed to verify payment:', error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
Adds verifyPayment method to StellarService that queries Horizon for a transaction by hash, checks destination/amount/asset match expected values, and returns verification result with payment details.

Closes #206