### PR TITLE
feat(payments-engine): add createAssetPayment function for custom Stellar assets

### DIFF
--- a/packages/payments-engine/dist/index.js
+++ b/packages/payments-engine/dist/index.js
@@ -33,6 +33,7 @@ __export(index_exports, {
   StellarService: () => StellarService,
   buildChannelCloseTransaction: () => buildChannelCloseTransaction,
   closePaymentChannel: () => closePaymentChannel,
+  createAssetPayment: () => createAssetPayment,
   sendStellarPayment: () => sendStellarPayment
 });
 module.exports = __toCommonJS(index_exports);
@@ -76,6 +77,29 @@ var StellarService = class {
       console.error("Stellar transaction failed:", error);
       throw error;
     }
+  }
+  async checkTrustline(destination, assetCode, assetIssuer) {
+    const account = await this.server.loadAccount(destination);
+    return account.balances.some(
+      (balance) => balance.asset_code === assetCode && balance.asset_issuer === assetIssuer
+    );
+  }
+  async createAssetPayment(params) {
+    const { destination, assetCode, assetIssuer, amount } = params;
+    const hasTrustline = await this.checkTrustline(destination, assetCode, assetIssuer);
+    if (!hasTrustline) {
+      throw new Error(
+        `Destination account ${destination} does not have a trustline for ${assetCode}:${assetIssuer}`
+      );
+    }
+    const transactionHash = await this.sendFunds(destination, amount, assetCode, assetIssuer);
+    return {
+      transactionHash,
+      assetCode,
+      assetIssuer,
+      amount,
+      destination
+    };
   }
   async verifyPayment(params) {
     const { txHash, expectedDestination, expectedAmount, expectedAssetCode, expectedAssetIssuer } = params;
@@ -285,10 +309,14 @@ var stellarService = new StellarService();
 async function sendStellarPayment(to, amount, asset) {
   return stellarService.sendFunds(to, amount.toString(), asset === "XLM" ? void 0 : asset);
 }
+async function createAssetPayment(params) {
+  return stellarService.createAssetPayment(params);
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   StellarService,
   buildChannelCloseTransaction,
   closePaymentChannel,
+  createAssetPayment,
   sendStellarPayment
 });

--- a/packages/payments-engine/dist/index.mjs
+++ b/packages/payments-engine/dist/index.mjs
@@ -38,6 +38,29 @@ var StellarService = class {
       throw error;
     }
   }
+  async checkTrustline(destination, assetCode, assetIssuer) {
+    const account = await this.server.loadAccount(destination);
+    return account.balances.some(
+      (balance) => balance.asset_code === assetCode && balance.asset_issuer === assetIssuer
+    );
+  }
+  async createAssetPayment(params) {
+    const { destination, assetCode, assetIssuer, amount } = params;
+    const hasTrustline = await this.checkTrustline(destination, assetCode, assetIssuer);
+    if (!hasTrustline) {
+      throw new Error(
+        `Destination account ${destination} does not have a trustline for ${assetCode}:${assetIssuer}`
+      );
+    }
+    const transactionHash = await this.sendFunds(destination, amount, assetCode, assetIssuer);
+    return {
+      transactionHash,
+      assetCode,
+      assetIssuer,
+      amount,
+      destination
+    };
+  }
   async verifyPayment(params) {
     const { txHash, expectedDestination, expectedAmount, expectedAssetCode, expectedAssetIssuer } = params;
     try {
@@ -246,9 +269,13 @@ var stellarService = new StellarService();
 async function sendStellarPayment(to, amount, asset) {
   return stellarService.sendFunds(to, amount.toString(), asset === "XLM" ? void 0 : asset);
 }
+async function createAssetPayment(params) {
+  return stellarService.createAssetPayment(params);
+}
 export {
   StellarService,
   buildChannelCloseTransaction,
   closePaymentChannel,
+  createAssetPayment,
   sendStellarPayment
 };

--- a/packages/payments-engine/src/index.ts
+++ b/packages/payments-engine/src/index.ts
@@ -1,4 +1,4 @@
-import { StellarService } from './stellar.service';
+import { StellarService, type AssetPaymentParams, type PaymentResult } from './stellar.service';
 
 const stellarService = new StellarService();
 
@@ -8,6 +8,10 @@ export async function sendStellarPayment(
   asset: string,
 ): Promise<string> {
   return stellarService.sendFunds(to, amount.toString(), asset === 'XLM' ? undefined : asset);
+}
+
+export async function createAssetPayment(params: AssetPaymentParams): Promise<PaymentResult> {
+  return stellarService.createAssetPayment(params);
 }
 export type {
   Horizon,

--- a/packages/payments-engine/src/stellar.service.ts
+++ b/packages/payments-engine/src/stellar.service.ts
@@ -27,6 +27,21 @@ export interface PaymentVerificationParams {
   expectedAssetIssuer?: string;
 }
 
+export interface AssetPaymentParams {
+  destination: string;
+  assetCode: string;
+  assetIssuer: string;
+  amount: string;
+}
+
+export interface PaymentResult {
+  transactionHash: string;
+  assetCode: string;
+  assetIssuer: string;
+  amount: string;
+  destination: string;
+}
+
 export interface PaymentVerificationResult {
   verified: boolean;
   amount: string;
@@ -102,6 +117,40 @@ export class StellarService {
       console.error('Stellar transaction failed:', error);
       throw error; // Rethrow to let the worker handle the failure state
     }
+  }
+
+  async checkTrustline(
+    destination: string,
+    assetCode: string,
+    assetIssuer: string,
+  ): Promise<boolean> {
+    const account = await this.server.loadAccount(destination);
+    return account.balances.some(
+      (balance) =>
+        (balance as StellarSdk.Horizon.HorizonApi.BalanceLineAsset).asset_code === assetCode &&
+        (balance as StellarSdk.Horizon.HorizonApi.BalanceLineAsset).asset_issuer === assetIssuer,
+    );
+  }
+
+  async createAssetPayment(params: AssetPaymentParams): Promise<PaymentResult> {
+    const { destination, assetCode, assetIssuer, amount } = params;
+
+    const hasTrustline = await this.checkTrustline(destination, assetCode, assetIssuer);
+    if (!hasTrustline) {
+      throw new Error(
+        `Destination account ${destination} does not have a trustline for ${assetCode}:${assetIssuer}`,
+      );
+    }
+
+    const transactionHash = await this.sendFunds(destination, amount, assetCode, assetIssuer);
+
+    return {
+      transactionHash,
+      assetCode,
+      assetIssuer,
+      amount,
+      destination,
+    };
   }
 
   async verifyPayment(params: PaymentVerificationParams): Promise<PaymentVerificationResult> {


### PR DESCRIPTION
Add AssetPaymentParams and PaymentResult interfaces, trustline verification, and createAssetPayment method on StellarService. Export from package index.

Closes #79