### PR TITLE
feat: integrate payments dashboard with real API

### DIFF
--- a/apps/api/src/payments/dto/list-payments.dto.ts
+++ b/apps/api/src/payments/dto/list-payments.dto.ts
@@ -1,0 +1,27 @@
+import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+const VALID_STATUSES = ['pending', 'detected', 'confirmed', 'failed'] as const;
+
+export class ListPaymentsDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsIn(VALID_STATUSES)
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -7,13 +7,15 @@ import {
   NotFoundException,
   Param,
   Post,
+  Query,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { CurrentMerchant } from '../auth/decorators/current-merchant.decorator.js';
 import { type MerchantUser } from '../auth/interfaces/merchant-user.interface.js';
 import { CreatePaymentIntentDto } from './dto/create-payment-intent.dto.js';
 import { GenerateDepositAddressDto } from './dto/generate-deposit-address.dto.js';
+import { ListPaymentsDto } from './dto/list-payments.dto.js';
 import { PaymentsService, type CreatePaymentIntentResponse } from './payments.service.js';
 import { DepositAddressService } from './deposit-address.service.js';
 import { DepositAddress } from './interfaces/deposit-address.interface.js';
@@ -88,14 +90,31 @@ export class PaymentsController {
     return this.depositAddressService.generateAddress(paymentId, dto.network);
   }
 
+  @Get()
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'List payment intents for the authenticated merchant' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['pending', 'detected', 'confirmed', 'failed'],
+  })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  listPayments(@CurrentMerchant() merchant: MerchantUser, @Query() query: ListPaymentsDto) {
+    return this.paymentsService.findAll(merchant.merchant_id, {
+      page: query.page ?? 1,
+      limit: query.limit ?? 20,
+      status: query.status,
+      search: query.search,
+    });
+  }
+
   @Get(':paymentId')
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Get a payment intent' })
   @ApiResponse({ status: 404, description: 'Payment intent not found' })
-  getPayment(
-    @Param('paymentId') paymentId: string,
-    @CurrentMerchant() merchant: MerchantUser,
-  ) {
+  getPayment(@Param('paymentId') paymentId: string, @CurrentMerchant() merchant: MerchantUser) {
     const intent = this.paymentsService.findOneOrFail(paymentId);
     if (intent.merchantId !== merchant.merchant_id) {
       throw new NotFoundException('Payment intent not found');

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -94,6 +94,36 @@ export class PaymentsService {
     return this.updateStatus(id, 'failed', WebhookEventType.PAYMENT_FAILED);
   }
 
+  findAll(
+    merchantId: string,
+    opts: { page: number; limit: number; status?: string; search?: string },
+  ): { data: StoredIntent[]; total: number; page: number; limit: number } {
+    let results = this.payments.filter((p) => p.merchantId === merchantId);
+
+    if (opts.status) {
+      results = results.filter((p) => p.status === opts.status);
+    }
+
+    if (opts.search) {
+      const q = opts.search.toLowerCase();
+      results = results.filter(
+        (p) =>
+          p.paymentId.toLowerCase().includes(q) ||
+          p.paymentReference.toLowerCase().includes(q) ||
+          p.currency.toLowerCase().includes(q) ||
+          (p.reference && p.reference.toLowerCase().includes(q)),
+      );
+    }
+
+    results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    const total = results.length;
+    const start = (opts.page - 1) * opts.limit;
+    const data = results.slice(start, start + opts.limit);
+
+    return { data, total, page: opts.page, limit: opts.limit };
+  }
+
   findOne(paymentId: string): StoredIntent | undefined {
     return this.payments.find((p) => p.paymentId === paymentId);
   }

--- a/apps/frontend/src/app/dashboard/payments/page.tsx
+++ b/apps/frontend/src/app/dashboard/payments/page.tsx
@@ -1,47 +1,90 @@
 'use client';
 
-import { motion } from "motion/react";
-import { Search, Filter, Download, ArrowUpRight, CheckCircle2, AlertCircle, Clock } from "lucide-react";
-import { useState } from "react";
+import { motion } from 'motion/react';
+import {
+  Search,
+  Filter,
+  Download,
+  ArrowUpRight,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+  Inbox,
+} from 'lucide-react';
+import { useEffect, useState, useCallback } from 'react';
+import { Skeleton } from '@/app/components/ui/skeleton';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/app/components/ui/pagination';
 
-const payments = [
-  {
-    id: "pay_9k2j3n4k5j6h7g8f",
-    date: "2026-03-03 14:32:15",
-    asset: "sUSDC",
-    amount: "12,450.00",
-    status: "completed",
-    rail: "Stellar Network",
-    hash: "0x7a8f9b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a",
-    from: "GABCD...WXYZ",
-    to: "GEFGH...STUV",
-  },
-  {
-    id: "pay_8h1j2k3l4m5n6o7p",
-    date: "2026-03-03 14:28:42",
-    asset: "sBTC",
-    amount: "0.2341",
-    status: "completed",
-    rail: "Stellar Network",
-    hash: "0x3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d",
-    from: "GIJKL...MNOP",
-    to: "GQRST...UVWX",
-  },
-  {
-    id: "pay_7g8h9i0j1k2l3m4n",
-    date: "2026-03-03 14:24:08",
-    asset: "sETH",
-    amount: "5.4321",
-    status: "pending",
-    rail: "Stellar Network",
-    hash: "0x1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t",
-    from: "GYZAB...CDEF",
-    to: "GGHIJ...KLMN",
-  },
-];
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
+
+interface Payment {
+  id: string;
+  paymentId: string;
+  paymentReference: string;
+  amount: number;
+  currency: string;
+  reference?: string;
+  status: 'pending' | 'detected' | 'confirmed' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+}
+
+interface PaymentsResponse {
+  data: Payment[];
+  total: number;
+  page: number;
+  limit: number;
+}
 
 export default function PaymentsPage() {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPayments = useCallback(
+    async (pageNum: number, search?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ page: String(pageNum), limit: String(limit) });
+        if (search) params.set('search', search);
+        const res = await fetch(`${API_BASE_URL}/payments?${params}`);
+        if (!res.ok) throw new Error(`Failed to load payments (${res.status})`);
+        const json: PaymentsResponse = await res.json();
+        setPayments(json.data);
+        setTotal(json.total);
+        setPage(json.page);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [limit],
+  );
+
+  useEffect(() => {
+    fetchPayments(page, searchQuery);
+  }, [page, fetchPayments, searchQuery]);
+
+  const handleSearch = (value: string) => {
+    setSearchQuery(value);
+    setPage(1);
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
 
   return (
     <div className="p-4 sm:p-6 lg:p-8">
@@ -54,9 +97,7 @@ export default function PaymentsPage() {
         >
           Payments
         </motion.h1>
-        <p className="text-sm text-neutral-400">
-          Track and manage all payment transactions
-        </p>
+        <p className="text-sm text-neutral-400">Track and manage all payment transactions</p>
       </div>
 
       {/* Filters */}
@@ -69,9 +110,9 @@ export default function PaymentsPage() {
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-5 text-neutral-500" />
           <input
             type="text"
-            placeholder="Search by ID, hash, or address..."
+            placeholder="Search by ID, reference, or currency..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => handleSearch(e.target.value)}
             className="w-full pl-10 pr-4 py-3 bg-white/5 border border-white/10 rounded-lg text-sm focus:outline-none focus:border-white/20 transition-colors"
           />
         </div>
@@ -88,10 +129,10 @@ export default function PaymentsPage() {
       {/* Stats */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {[
-          { label: "Total Payments", value: "1,247" },
-          { label: "Completed", value: "1,198" },
-          { label: "Pending", value: "47" },
-          { label: "Failed", value: "2" },
+          { label: 'Total Payments', value: total },
+          { label: 'Confirmed', value: payments.filter((p) => p.status === 'confirmed').length },
+          { label: 'Pending', value: payments.filter((p) => p.status === 'pending').length },
+          { label: 'Failed', value: payments.filter((p) => p.status === 'failed').length },
         ].map((stat, index) => (
           <motion.div
             key={stat.label}
@@ -100,11 +141,35 @@ export default function PaymentsPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: index * 0.1 }}
           >
-            <div className="text-2xl font-medium mb-1">{stat.value}</div>
+            <div className="text-2xl font-medium mb-1">
+              {loading ? (
+                <Skeleton className="h-8 w-16 inline-block" />
+              ) : (
+                stat.value.toLocaleString()
+              )}
+            </div>
             <div className="text-xs text-neutral-500">{stat.label}</div>
           </motion.div>
         ))}
       </div>
+
+      {/* Error State */}
+      {error && (
+        <motion.div
+          className="mb-6 p-4 bg-red-400/10 border border-red-400/20 rounded-lg flex items-center gap-3 text-red-400 text-sm"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <AlertCircle className="size-5 shrink-0" />
+          <span>{error}</span>
+          <button
+            onClick={() => fetchPayments(page, searchQuery)}
+            className="ml-auto underline hover:no-underline cursor-pointer"
+          >
+            Retry
+          </button>
+        </motion.div>
+      )}
 
       {/* Payments Table */}
       <motion.div
@@ -117,71 +182,173 @@ export default function PaymentsPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-white/5 bg-white/[0.02]">
-                <th className="text-left py-4 px-4 text-neutral-500 font-medium whitespace-nowrap">Payment ID</th>
-                <th className="text-left py-4 px-4 text-neutral-500 font-medium whitespace-nowrap">Date & Time</th>
+                <th className="text-left py-4 px-4 text-neutral-500 font-medium whitespace-nowrap">
+                  Payment ID
+                </th>
+                <th className="text-left py-4 px-4 text-neutral-500 font-medium whitespace-nowrap">
+                  Date & Time
+                </th>
                 <th className="text-left py-4 px-4 text-neutral-500 font-medium">Asset</th>
                 <th className="text-left py-4 px-4 text-neutral-500 font-medium">Amount</th>
                 <th className="text-left py-4 px-4 text-neutral-500 font-medium">Status</th>
-                <th className="text-left py-4 px-4 text-neutral-500 font-medium">Rail</th>
-                <th className="text-left py-4 px-4 text-neutral-500 font-medium whitespace-nowrap">On-chain Hash</th>
+                <th className="text-left py-4 px-4 text-neutral-500 font-medium">Reference</th>
                 <th className="text-left py-4 px-4 text-neutral-500 font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {payments.map((payment, index) => (
-                <motion.tr
-                  key={payment.id}
-                  className="border-b border-white/5 hover:bg-white/[0.02] transition-colors"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.4 + index * 0.05 }}
-                >
-                  <td className="py-4 px-4">
-                    <div className="font-mono text-xs">{payment.id}</div>
+              {loading ? (
+                Array.from({ length: limit }).map((_, i) => (
+                  <tr key={`skeleton-${i}`} className="border-b border-white/5">
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-4 w-32" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-4 w-28" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-6 w-14" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-4 w-20" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-6 w-20" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-4 w-24" />
+                    </td>
+                    <td className="py-4 px-4">
+                      <Skeleton className="h-4 w-4" />
+                    </td>
+                  </tr>
+                ))
+              ) : payments.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="py-16 text-center">
+                    <div className="flex flex-col items-center gap-3 text-neutral-500">
+                      <Inbox className="size-10" />
+                      <span className="text-sm">
+                        {searchQuery ? 'No payments match your search.' : 'No payments found.'}
+                      </span>
+                    </div>
                   </td>
-                  <td className="py-4 px-4 text-neutral-400 whitespace-nowrap">{payment.date}</td>
-                  <td className="py-4 px-4">
-                    <span className="px-2 py-1 bg-white/5 rounded text-xs font-medium">
-                      {payment.asset}
-                    </span>
-                  </td>
-                  <td className="py-4 px-4 font-medium">{payment.amount}</td>
-                  <td className="py-4 px-4">
-                    <span
-                      className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs whitespace-nowrap ${
-                        payment.status === "completed"
-                          ? "bg-green-400/10 text-green-400"
-                          : payment.status === "pending"
-                          ? "bg-yellow-400/10 text-yellow-400"
-                          : "bg-red-400/10 text-red-400"
-                      }`}
-                    >
-                      {payment.status === "completed" ? (
-                        <CheckCircle2 className="size-3" />
-                      ) : payment.status === "pending" ? (
-                        <Clock className="size-3" />
-                      ) : (
-                        <AlertCircle className="size-3" />
-                      )}
-                      {payment.status}
-                    </span>
-                  </td>
-                  <td className="py-4 px-4 text-neutral-400 whitespace-nowrap">{payment.rail}</td>
-                  <td className="py-4 px-4">
-                    <button className="font-mono text-xs text-neutral-500 hover:text-white transition-colors cursor-pointer">
-                      {payment.hash.slice(0, 16)}...
-                    </button>
-                  </td>
-                  <td className="py-4 px-4">
-                    <button className="text-white hover:text-neutral-400 transition-colors cursor-pointer">
-                      <ArrowUpRight className="size-4" />
-                    </button>
-                  </td>
-                </motion.tr>
-              ))}
+                </tr>
+              ) : (
+                payments.map((payment, index) => (
+                  <motion.tr
+                    key={payment.id}
+                    className="border-b border-white/5 hover:bg-white/[0.02] transition-colors"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.05 * index }}
+                  >
+                    <td className="py-4 px-4">
+                      <div className="font-mono text-xs">{payment.paymentReference}</div>
+                    </td>
+                    <td className="py-4 px-4 text-neutral-400 whitespace-nowrap">
+                      {new Date(payment.createdAt).toLocaleString()}
+                    </td>
+                    <td className="py-4 px-4">
+                      <span className="px-2 py-1 bg-white/5 rounded text-xs font-medium">
+                        {payment.currency}
+                      </span>
+                    </td>
+                    <td className="py-4 px-4 font-medium">{payment.amount.toLocaleString()}</td>
+                    <td className="py-4 px-4">
+                      <span
+                        className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs whitespace-nowrap ${
+                          payment.status === 'confirmed'
+                            ? 'bg-green-400/10 text-green-400'
+                            : payment.status === 'pending'
+                              ? 'bg-yellow-400/10 text-yellow-400'
+                              : payment.status === 'detected'
+                                ? 'bg-blue-400/10 text-blue-400'
+                                : 'bg-red-400/10 text-red-400'
+                        }`}
+                      >
+                        {payment.status === 'confirmed' ? (
+                          <CheckCircle2 className="size-3" />
+                        ) : payment.status === 'pending' || payment.status === 'detected' ? (
+                          <Clock className="size-3" />
+                        ) : (
+                          <AlertCircle className="size-3" />
+                        )}
+                        {payment.status}
+                      </span>
+                    </td>
+                    <td className="py-4 px-4 text-neutral-400 text-xs">
+                      {payment.reference ?? '—'}
+                    </td>
+                    <td className="py-4 px-4">
+                      <button className="text-white hover:text-neutral-400 transition-colors cursor-pointer">
+                        <ArrowUpRight className="size-4" />
+                      </button>
+                    </td>
+                  </motion.tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="border-t border-white/5 py-4 px-4">
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      if (page > 1) setPage(page - 1);
+                    }}
+                    className={page <= 1 ? 'pointer-events-none opacity-50' : ''}
+                  />
+                </PaginationItem>
+                {Array.from({ length: totalPages }, (_, i) => i + 1)
+                  .filter((p) => p === 1 || p === totalPages || Math.abs(p - page) <= 1)
+                  .reduce<(number | 'ellipsis')[]>((acc, p, i, arr) => {
+                    if (i > 0 && p - (arr[i - 1] as number) > 1) acc.push('ellipsis');
+                    acc.push(p);
+                    return acc;
+                  }, [])
+                  .map((item, i) =>
+                    item === 'ellipsis' ? (
+                      <PaginationItem key={`ellipsis-${i}`}>
+                        <span className="flex size-9 items justify-center text-neutral-500">
+                          ...
+                        </span>
+                      </PaginationItem>
+                    ) : (
+                      <PaginationItem key={item}>
+                        <PaginationLink
+                          href="#"
+                          isActive={item === page}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setPage(item);
+                          }}
+                        >
+                          {item}
+                        </PaginationLink>
+                      </PaginationItem>
+                    ),
+                  )}
+                <PaginationItem>
+                  <PaginationNext
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      if (page < totalPages) setPage(page + 1);
+                    }}
+                    className={page >= totalPages ? 'pointer-events-none opacity-50' : ''}
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
+        )}
       </motion.div>
     </div>
   );


### PR DESCRIPTION
Closes #225

### Summary
Replaces hardcoded mock payment data on the dashboard payments page with real API calls to `GET /payments`, adds pagination, and handles loading/empty/error states.

### Changes

**Backend (`apps/api/src/payments/`)**
- Added `GET /payments` endpoint with JWT auth, supporting `page`, `limit`, `status`, and `search` query parameters
- Added `findAll()` method to `PaymentsService` with filtering by merchant, status, and search text, sorted by newest first
- Created `ListPaymentsDto` for validated query parameter input

**Frontend (`apps/frontend/src/app/dashboard/payments/`)**
- Replaced inline mock data array with a `fetch` call to `GET /payments?page=&limit=&search=`
- Integrated existing shadcn `Pagination` component with prev/next buttons, page numbers, and ellipsis for large page counts
- Added skeleton loading state for stats cards and table rows
- Added empty state with contextual messaging (no data vs no search results)
- Added error state banner with retry button
- Search input triggers re-fetch with page reset

### Verification
- `pnpm --filter frontend build` passes successfully
- TypeScript compilation clean for both frontend and backend