### PR TITLE
feat(payments-engine): add validateAmount utility for Stellar assets …

### DIFF
--- a/packages/payments-engine/src/stellar.service.test.ts
+++ b/packages/payments-engine/src/stellar.service.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { validateAmount, StellarService } from './stellar.service';
+
+describe('validateAmount', () => {
+  const stellarService = new StellarService();
+
+  it('validates a correct positive amount within Stellar precision', () => {
+    const result = validateAmount('10.5');
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    const serviceResult = stellarService.validateAmount('10.5');
+    expect(serviceResult.valid).toBe(true);
+  });
+
+  it('validates amount at the maximum allowed decimal precision (7 decimals)', () => {
+    const result = validateAmount('0.1234567');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects amount exceeding 7 decimal places', () => {
+    const result = validateAmount('0.12345678');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('7 decimal places');
+  });
+
+  it('rejects zero or negative amounts', () => {
+    const zeroResult = validateAmount('0');
+    expect(zeroResult.valid).toBe(false);
+    expect(zeroResult.error).toBe('Amount must be a positive number');
+
+    const negResult = validateAmount('-5');
+    expect(negResult.valid).toBe(false);
+    expect(negResult.error).toBe('Invalid amount format');
+  });
+
+  it('rejects non-numeric or empty string formats', () => {
+    expect(validateAmount('').valid).toBe(false);
+    expect(validateAmount('   ').valid).toBe(false);
+    expect(validateAmount('abc').valid).toBe(false);
+    expect(validateAmount('10.5.2').valid).toBe(false);
+  });
+
+  it('checks asset-specific minimum limits (e.g. XLM minimum 0.00001)', () => {
+    const belowMinXlm = validateAmount('0.000005', 'XLM');
+    expect(belowMinXlm.valid).toBe(false);
+    expect(belowMinXlm.error).toContain('below the minimum required amount of 0.00001 for XLM');
+
+    const exactMinXlm = validateAmount('0.00001', 'XLM');
+    expect(exactMinXlm.valid).toBe(true);
+
+    const belowMinUsdc = validateAmount('0.000001', 'USDC');
+    expect(belowMinUsdc.valid).toBe(false);
+    expect(belowMinUsdc.error).toContain('below the minimum required amount');
+  });
+});

--- a/packages/payments-engine/src/stellar.service.ts
+++ b/packages/payments-engine/src/stellar.service.ts
@@ -155,6 +155,65 @@ type IncomingPaymentRecord =
   | StellarSdk.Horizon.ServerApi.PathPaymentOperationRecord
   | StellarSdk.Horizon.ServerApi.PathPaymentStrictSendOperationRecord;
 
+export interface AmountValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+const ASSET_MINIMUM_AMOUNTS: Record<string, number> = {
+  XLM: 0.00001,
+  NATIVE: 0.00001,
+  USDC: 0.00001,
+  EURC: 0.00001,
+};
+
+export function validateAmount(
+  amount: string,
+  assetCode?: string,
+): AmountValidationResult {
+  if (typeof amount !== 'string' || amount.trim() === '') {
+    return { valid: false, error: 'Amount must be a non-empty string' };
+  }
+
+  const trimmed = amount.trim();
+
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    return { valid: false, error: 'Invalid amount format' };
+  }
+
+  const num = parseFloat(trimmed);
+
+  if (isNaN(num) || !isFinite(num)) {
+    return { valid: false, error: 'Invalid amount format' };
+  }
+
+  if (num <= 0) {
+    return { valid: false, error: 'Amount must be a positive number' };
+  }
+
+  if (trimmed.includes('.')) {
+    const decimals = trimmed.split('.')[1];
+    if (decimals && decimals.length > 7) {
+      return {
+        valid: false,
+        error: 'Amount exceeds maximum Stellar decimal precision (7 decimal places)',
+      };
+    }
+  }
+
+  const code = (assetCode || 'XLM').toUpperCase();
+  const minAmount = ASSET_MINIMUM_AMOUNTS[code] ?? 0.00001;
+
+  if (num < minAmount) {
+    return {
+      valid: false,
+      error: `Amount is below the minimum required amount of ${minAmount} for ${code}`,
+    };
+  }
+
+  return { valid: true };
+}
+
 export class StellarService {
   private server: StellarSdk.Horizon.Server;
   private sourceKeypair!: StellarSdk.Keypair;
@@ -174,6 +233,13 @@ export class StellarService {
     } catch {
       console.warn('Invalid STELLAR_STORAGE_SECRET. Stellar operations will fail.');
     }
+  }
+
+  /**
+   * Validates a Stellar payment amount.
+   */
+  validateAmount(amount: string, assetCode?: string): AmountValidationResult {
+    return validateAmount(amount, assetCode);
   }
 
   /**


### PR DESCRIPTION
Closes #213

## Summary
Add `validateAmount` function to `@stellar-pay/payments-engine` package to validate transaction amounts for Stellar assets.

## Changes Made
- Added `validateAmount(amount: string, assetCode?: string): AmountValidationResult` exported function and `StellarService.prototype.validateAmount` public method in `packages/payments-engine/src/stellar.service.ts`.
- Validates that amounts are non-empty, positive numeric strings.
- Enforces Stellar's maximum 7 decimal places limit (stroop precision).
- Enforces asset-specific minimum limits (e.g., 0.00001 minimum for XLM, USDC, EURC).
- Added comprehensive unit test suite in `packages/payments-engine/src/stellar.service.test.ts`.

## Verification
- Unit test suite: `pnpm --filter @stellar-pay/payments-engine test` (12/12 passing).
- Build compilation: `pnpm --filter @stellar-pay/payments-engine build` (clean build).
