### PR TITLE
feat: integrate treasury dashboard with real API (#226)

### DIFF
--- a/apps/api/src/treasury/interfaces/proof-of-reserves.interface.ts
+++ b/apps/api/src/treasury/interfaces/proof-of-reserves.interface.ts
@@ -11,6 +11,13 @@ export interface ProofOfReservesResponse {
   reserves: AssetReserve[];
 }
 
+export interface TreasuryBalanceResponse {
+  total_treasury_value: number;
+  total_reserve_backing: number;
+  active_assets: number;
+  assets: AssetReserve[];
+}
+
 export interface RedeemResponse {
   redemption_id: string;
   amount: number;

--- a/apps/api/src/treasury/treasury.controller.ts
+++ b/apps/api/src/treasury/treasury.controller.ts
@@ -2,7 +2,11 @@ import { Body, Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/commo
 import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { TreasuryService } from './treasury.service';
-import { ProofOfReservesResponse, RedeemResponse } from './interfaces/proof-of-reserves.interface';
+import {
+  ProofOfReservesResponse,
+  RedeemResponse,
+  TreasuryBalanceResponse,
+} from './interfaces/proof-of-reserves.interface';
 import { RedeemDto } from './dto/redeem.dto';
 import { CurrentMerchant } from '../auth/decorators/current-merchant.decorator';
 import type { MerchantUser } from '../auth/interfaces/merchant-user.interface';
@@ -11,6 +15,28 @@ import type { MerchantUser } from '../auth/interfaces/merchant-user.interface';
 @Controller('treasury')
 export class TreasuryController {
   constructor(private readonly treasuryService: TreasuryService) {}
+
+  @Get('balance')
+  async getBalance(): Promise<TreasuryBalanceResponse> {
+    const supportedAssets = (process.env.SUPPORTED_ASSETS ?? 'USDC,ARS').split(',');
+    const reserves = await Promise.all(
+      supportedAssets.map((asset) => this.treasuryService.getAssetReserve(asset.trim())),
+    );
+    const totalValue = reserves.reduce(
+      (sum, r) => sum + parseFloat(r.treasury_balance),
+      0,
+    );
+    const totalReserves = reserves.reduce(
+      (sum, r) => sum + parseFloat(r.total_supply),
+      0,
+    );
+    return {
+      total_treasury_value: totalValue,
+      total_reserve_backing: totalReserves,
+      active_assets: reserves.length,
+      assets: reserves,
+    };
+  }
 
   @Get('reserves')
   async getProofOfReserves(): Promise<ProofOfReservesResponse> {

--- a/apps/api/src/treasury/treasury.service.ts
+++ b/apps/api/src/treasury/treasury.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import * as StellarSdk from '@stellar/stellar-sdk';
-import { RedeemResponse } from './interfaces/proof-of-reserves.interface';
+import { AssetReserve, RedeemResponse } from './interfaces/proof-of-reserves.interface';
 import { RedemptionRepository } from '../modules/database/redemption.repository';
 import { RedeemDto } from './dto/redeem.dto';
 
@@ -58,6 +58,25 @@ export class TreasuryService {
       (b): b is HorizonBalanceRecord => b.asset_code === assetCode && b.asset_issuer === issuer,
     );
     return balance?.balance ?? '0';
+  }
+
+  async getAssetReserve(assetCode: string): Promise<AssetReserve> {
+    const treasuryAddress =
+      process.env.TREASURY_WALLET_ADDRESS ??
+      'GAKMS4ZQ5G5XK4Q5G5XK4Q5G5XK4Q5G5XK4Q5G5XK4Q5G5XK4Q5G5XK4Q5';
+    const [totalSupply, treasuryBalance] = await Promise.all([
+      this.getTotalSupply(assetCode),
+      this.getTreasuryBalance(assetCode, treasuryAddress),
+    ]);
+    const supply = parseFloat(totalSupply) || 1;
+    const balance = parseFloat(treasuryBalance) || 0;
+    const reserveRatio = parseFloat(((balance / supply) * 100).toFixed(2));
+    return {
+      symbol: assetCode,
+      total_supply: totalSupply,
+      treasury_balance: treasuryBalance,
+      reserve_ratio: reserveRatio,
+    };
   }
 
   /**

--- a/apps/frontend/src/app/dashboard/treasury/page.tsx
+++ b/apps/frontend/src/app/dashboard/treasury/page.tsx
@@ -1,40 +1,30 @@
 'use client';
 
 import { motion } from "motion/react";
-import { Coins, TrendingUp, Eye, CheckCircle2 } from "lucide-react";
+import { Coins, TrendingUp, Eye, CheckCircle2, AlertCircle, RefreshCw } from "lucide-react";
+import { useEffect, useState, useCallback } from "react";
+import { Skeleton } from "@/app/components/ui/skeleton";
 
-const mirrorAssets = [
-  {
-    symbol: 'sUSDC',
-    name: 'Stellar USDC',
-    balance: '1,245,382.45',
-    usdValue: '1,245,382.45',
-    reserves: '1,286,529.42',
-    reserveRatio: '103.3%',
-    redeemable: true,
-    burnHistory: '342 burns',
-  },
-  {
-    symbol: 'sBTC',
-    name: 'Stellar Bitcoin',
-    balance: '12.4583',
-    usdValue: '625,847.92',
-    reserves: '12.8731',
-    reserveRatio: '103.3%',
-    redeemable: true,
-    burnHistory: '87 burns',
-  },
-  {
-    symbol: 'sETH',
-    name: 'Stellar Ethereum',
-    balance: '145.2341',
-    usdValue: '232,251.75',
-    reserves: '150.1248',
-    reserveRatio: '103.4%',
-    redeemable: true,
-    burnHistory: '156 burns',
-  },
-];
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
+
+interface AssetReserve {
+  symbol: string;
+  total_supply: string;
+  treasury_balance: string;
+  reserve_ratio: number;
+}
+
+interface TreasuryBalanceResponse {
+  total_treasury_value: number;
+  total_reserve_backing: number;
+  active_assets: number;
+  assets: AssetReserve[];
+}
+
+const assetNames: Record<string, string> = {
+  USDC: 'Stellar USDC',
+  ARS: 'Stellar ARS',
+};
 
 const burnHistory = [
   { date: '2026-03-03 14:32', asset: 'sUSDC', amount: '5,000.00', hash: '0x7a8f9b...4e5d6f' },
@@ -44,9 +34,48 @@ const burnHistory = [
 ];
 
 export default function TreasuryPage() {
+  const [data, setData] = useState<TreasuryBalanceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE_URL}/treasury/balance`);
+      if (!res.ok) throw new Error(`Failed to load treasury data (${res.status})`);
+      const json: TreasuryBalanceResponse = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBalance();
+  }, [fetchBalance]);
+
+  const overviewStats = [
+    { label: 'Total Treasury Value', value: data ? `$${data.total_treasury_value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : null, icon: Coins },
+    { label: 'Reserve Backing', value: data ? `$${data.total_reserve_backing.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : null, icon: CheckCircle2 },
+    { label: 'Liquidity Health', value: data ? (data.assets.every(a => a.reserve_ratio >= 100) ? 'Excellent' : 'Good') : null, icon: TrendingUp },
+    { label: 'Active Assets', value: data ? String(data.active_assets) : null, icon: Coins },
+  ];
+
+  const avgReserveRatio = data && data.assets.length > 0
+    ? data.assets.reduce((sum, a) => sum + a.reserve_ratio, 0) / data.assets.length
+    : 0;
+
+  const liquidityMetrics = data ? [
+    { label: 'Overall Health', value: Math.min(Math.round(avgReserveRatio), 100), status: avgReserveRatio >= 100 ? 'Excellent' : 'Good' },
+    { label: 'Reserve Coverage', value: Math.round(avgReserveRatio), status: avgReserveRatio >= 100 ? 'Strong' : 'Adequate' },
+    { label: 'Redemption Capacity', value: Math.min(Math.round(avgReserveRatio * 0.85), 100), status: 'Good' },
+  ] : [];
+
   return (
     <div className="p-4 sm:p-6 lg:p-8">
-      {/* Header */}
       <div className="mb-8">
         <motion.h1
           className="text-2xl sm:text-3xl font-medium mb-2"
@@ -58,14 +87,27 @@ export default function TreasuryPage() {
         <p className="text-sm text-neutral-400">Manage mirror assets, reserves, and redemptions</p>
       </div>
 
+      {/* Error State */}
+      {error && (
+        <motion.div
+          className="mb-6 p-4 bg-red-400/10 border border-red-400/20 rounded-lg flex items-center gap-3 text-red-400 text-sm"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <AlertCircle className="size-5 shrink-0" />
+          <span>{error}</span>
+          <button
+            onClick={fetchBalance}
+            className="ml-auto underline hover:no-underline cursor-pointer"
+          >
+            Retry
+          </button>
+        </motion.div>
+      )}
+
       {/* Treasury Overview */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        {[
-          { label: 'Total Treasury Value', value: '$2,103,482.12', icon: Coins },
-          { label: 'Reserve Backing', value: '$2,173,402.45', icon: CheckCircle2 },
-          { label: 'Liquidity Health', value: 'Excellent', icon: TrendingUp },
-          { label: 'Active Assets', value: '3', icon: Coins },
-        ].map((stat, index) => (
+        {overviewStats.map((stat, index) => (
           <motion.div
             key={stat.label}
             className="p-6 bg-gradient-to-br from-white/[0.05] to-transparent border border-white/10 rounded-xl"
@@ -78,7 +120,9 @@ export default function TreasuryPage() {
                 <stat.icon className="size-5" />
               </div>
             </div>
-            <div className="text-2xl font-medium mb-1">{stat.value}</div>
+            <div className="text-2xl font-medium mb-1">
+              {loading ? <Skeleton className="h-8 w-28 inline-block" /> : stat.value}
+            </div>
             <div className="text-xs text-neutral-500">{stat.label}</div>
           </motion.div>
         ))}
@@ -94,7 +138,29 @@ export default function TreasuryPage() {
         <h2 className="text-lg font-medium mb-6">Mirror Assets</h2>
 
         <div className="space-y-4">
-          {mirrorAssets.map((asset, index) => (
+          {loading ? Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="p-6 bg-white/[0.02] border border-white/5 rounded-lg">
+              <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <div>
+                  <Skeleton className="h-12 w-32" />
+                </div>
+                <div>
+                  <Skeleton className="h-4 w-16 mb-2" />
+                  <Skeleton className="h-6 w-28 mb-1" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <div>
+                  <Skeleton className="h-4 w-24 mb-2" />
+                  <Skeleton className="h-6 w-28 mb-1" />
+                  <Skeleton className="h-4 w-16" />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              </div>
+            </div>
+          )) : data?.assets.map((asset, index) => (
             <motion.div
               key={asset.symbol}
               className="p-6 bg-white/[0.02] border border-white/5 rounded-lg hover:border-white/10 transition-all"
@@ -103,37 +169,32 @@ export default function TreasuryPage() {
               transition={{ delay: 0.4 + index * 0.1 }}
             >
               <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-                {/* Asset Info */}
                 <div>
                   <div className="flex items-center gap-3 mb-3">
                     <div className="w-12 h-12 rounded-full bg-gradient-to-br from-white/20 to-white/10 flex items-center justify-center font-medium">
-                      {asset.symbol.slice(1, 3)}
+                      {asset.symbol.slice(0, 2)}
                     </div>
                     <div>
-                      <div className="font-medium">{asset.symbol}</div>
-                      <div className="text-xs text-neutral-500">{asset.name}</div>
+                      <div className="font-medium">s{asset.symbol}</div>
+                      <div className="text-xs text-neutral-500">{assetNames[asset.symbol] ?? asset.symbol}</div>
                     </div>
                   </div>
                 </div>
 
-                {/* Balance */}
                 <div>
                   <div className="text-xs text-neutral-500 mb-1">Balance</div>
-                  <div className="font-medium">{asset.balance}</div>
-                  <div className="text-xs text-neutral-400">${asset.usdValue}</div>
+                  <div className="font-medium">{parseFloat(asset.treasury_balance).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}</div>
                 </div>
 
-                {/* Reserves */}
                 <div>
                   <div className="text-xs text-neutral-500 mb-1">Reserve Backing</div>
-                  <div className="font-medium">{asset.reserves}</div>
+                  <div className="font-medium">{parseFloat(asset.total_supply).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}</div>
                   <div className="flex items-center gap-1 text-xs text-green-400">
                     <CheckCircle2 className="size-3" />
-                    {asset.reserveRatio}
+                    {asset.reserve_ratio}%
                   </div>
                 </div>
 
-                {/* Actions */}
                 <div className="flex flex-col gap-2">
                   <button className="px-4 py-2 bg-white text-black rounded-lg hover:bg-neutral-200 transition-all text-sm font-medium cursor-pointer">
                     Redeem
@@ -195,11 +256,13 @@ export default function TreasuryPage() {
           <h2 className="text-lg font-medium mb-6">Liquidity Health Metrics</h2>
 
           <div className="space-y-6">
-            {[
-              { label: 'Overall Health', value: 95, status: 'Excellent' },
-              { label: 'Reserve Coverage', value: 103, status: 'Strong' },
-              { label: 'Redemption Capacity', value: 88, status: 'Good' },
-            ].map((metric, index) => (
+            {loading ? Array.from({ length: 3 }).map((_, i) => (
+              <div key={i}>
+                <Skeleton className="h-4 w-32 mb-2" />
+                <Skeleton className="h-2 w-full mb-1" />
+                <Skeleton className="h-3 w-8 ml-auto" />
+              </div>
+            )) : liquidityMetrics.map((metric, index) => (
               <div key={metric.label}>
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-sm text-neutral-400">{metric.label}</span>


### PR DESCRIPTION
- Add getAssetReserve method to TreasuryService (fetches total supply
  + treasury balance from Horizon, computes reserve ratio)
- Add GET /treasury/balance endpoint returning aggregated overview
- Add TreasuryBalanceResponse interface
- Rewrite treasury page to fetch from /treasury/balance API
- Add loading skeletons, error state with retry
- Compute liquidity health metrics from real reserve ratios
- Keep burn history as static placeholder (no API endpoint yet)

closes: #226