### PR TITLE
feat: add PUT /merchants/profile endpoint (#256)

### DIFF
--- a/apps/api/src/merchants/dto/update-merchant-profile.dto.ts
+++ b/apps/api/src/merchants/dto/update-merchant-profile.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsOptional, IsString } from 'class-validator';
+
+export class UpdateMerchantProfileDto {
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}

--- a/apps/api/src/merchants/merchants.controller.ts
+++ b/apps/api/src/merchants/merchants.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, NotFoundException, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Put, UseGuards } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CurrentMerchant } from '../auth/decorators/current-merchant.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import type { MerchantUser } from '../auth/interfaces/merchant-user.interface';
+import { UpdateMerchantProfileDto } from './dto/update-merchant-profile.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('merchants')
@@ -21,5 +22,21 @@ export class MerchantsController {
     }
 
     return merchant;
+  }
+
+  @Put('profile')
+  async updateProfile(
+    @CurrentMerchant() currentMerchant: MerchantUser,
+    @Body() dto: UpdateMerchantProfileDto,
+  ) {
+    const merchant = await this.prisma.merchant.update({
+      where: { id: currentMerchant.merchant_id },
+      data: {
+        ...(dto.email !== undefined && { email: dto.email }),
+        ...(dto.name !== undefined && { name: dto.name }),
+      },
+    });
+
+    return { id: merchant.id, email: merchant.email, name: merchant.name };
   }
 }

--- a/packages/database/migrations/schema.prisma
+++ b/packages/database/migrations/schema.prisma
@@ -40,6 +40,7 @@ enum UserRole {
 model Merchant {
   id           String    @id @default(uuid()) @db.Uuid
   email        String    @unique
+  name         String?
   passwordHash String    @map("password_hash")
   kycStatus    KycStatus @default(PENDING) @map("kyc_status")
   createdAt    DateTime  @default(now()) @map("created_at")


### PR DESCRIPTION
## Summary

Add `PUT /merchants/profile` endpoint to update the authenticated merchant's profile.

### Changes

- **`merchants.controller.ts`**: Added `updateProfile()` handler for `PUT /merchants/profile` — accepts partial merchant data (email, name), updates via PrismaService, returns updated merchant ID/email/name.
- **`dto/update-merchant-profile.dto.ts`**: Created DTO with `@IsOptional()` + `@IsEmail()` for `email` and `@IsOptional()` + `@IsString()` for `name`.
- **`schema.prisma`**: Added optional `name` field to the `Merchant` model.

### Verification

- `pnpm --filter api build` passes (no new errors; 77 pre-existing errors in treasury/webhooks are unchanged).

Closes: #256
