### PR TITLE
feat: add error boundaries to frontend components (#228)

### DIFF
--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -21,6 +21,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 const navigation = [
   { name: 'Overview', href: '/dashboard', icon: LayoutDashboard },
@@ -139,7 +140,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
       {/* Main content */}
       <div className="lg:pl-64 pt-16 lg:pt-0">
-        <main className="min-h-screen">{children}</main>
+        <main className="min-h-screen">
+          <ErrorBoundary name="Page">
+            {children}
+          </ErrorBoundary>
+        </main>
       </div>
 
       {/* Mobile overlay */}

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   AlertCircle,
 } from 'lucide-react';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useState } from 'react';
 
 const stats = [
@@ -120,6 +121,7 @@ export default function OverviewPage() {
       </div>
 
       {/* Stats Grid */}
+      <ErrorBoundary name="Stats Grid">
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {stats.map((stat, index) => (
           <motion.div
@@ -167,7 +169,9 @@ export default function OverviewPage() {
           </motion.div>
         ))}
       </div>
+      </ErrorBoundary>
 
+      <ErrorBoundary name="Asset Balances">
       <div className="grid lg:grid-cols-3 gap-6 mb-8">
         {/* Asset Balances */}
         <motion.div
@@ -286,7 +290,9 @@ export default function OverviewPage() {
           </div>
         </motion.div>
       </div>
+      </ErrorBoundary>
 
+      <ErrorBoundary name="Transaction Feed">
       {/* Real-time Transaction Feed */}
       <motion.div
         className="p-6 bg-gradient-to-br from-white/[0.03] to-transparent border border-white/5 rounded-xl"
@@ -376,6 +382,7 @@ export default function OverviewPage() {
           </table>
         </div>
       </motion.div>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/apps/frontend/src/app/dashboard/treasury/page.tsx
+++ b/apps/frontend/src/app/dashboard/treasury/page.tsx
@@ -4,6 +4,7 @@ import { motion } from "motion/react";
 import { Coins, TrendingUp, Eye, CheckCircle2, AlertCircle, RefreshCw } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
 import { Skeleton } from "@/app/components/ui/skeleton";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
 
@@ -128,6 +129,7 @@ export default function TreasuryPage() {
         ))}
       </div>
 
+      <ErrorBoundary name="Mirror Assets">
       {/* Mirror Assets */}
       <motion.div
         className="mb-8 p-6 bg-gradient-to-br from-white/[0.03] to-transparent border border-white/5 rounded-xl"
@@ -210,7 +212,10 @@ export default function TreasuryPage() {
         </div>
       </motion.div>
 
+      </ErrorBoundary>
+
       <div className="grid lg:grid-cols-2 gap-6">
+        <ErrorBoundary name="Burn History">
         {/* Burn History */}
         <motion.div
           className="p-6 bg-gradient-to-br from-white/[0.03] to-transparent border border-white/5 rounded-xl"
@@ -246,6 +251,9 @@ export default function TreasuryPage() {
           </div>
         </motion.div>
 
+        </ErrorBoundary>
+
+        <ErrorBoundary name="Liquidity Health">
         {/* Liquidity Health */}
         <motion.div
           className="p-6 bg-gradient-to-br from-white/[0.03] to-transparent border border-white/5 rounded-xl"
@@ -281,6 +289,7 @@ export default function TreasuryPage() {
             ))}
           </div>
         </motion.div>
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/ErrorBoundary.tsx
+++ b/apps/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { motion } from 'motion/react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  name?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(`[ErrorBoundary${this.props.name ? `: ${this.props.name}` : ''}]`, error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <motion.div
+          className="p-6 bg-gradient-to-br from-red-500/[0.05] to-transparent border border-red-500/20 rounded-xl"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <div className="flex flex-col items-center text-center py-8">
+            <div className="p-3 bg-red-400/10 rounded-full mb-4">
+              <AlertTriangle className="size-6 text-red-400" />
+            </div>
+            <h3 className="text-lg font-medium mb-2">
+              {this.props.name ?? 'Section'} crashed
+            </h3>
+            <p className="text-sm text-neutral-400 mb-4 max-w-md">
+              Something went wrong while rendering this section. The rest of the page should still be working.
+            </p>
+            {this.state.error && (
+              <p className="text-xs font-mono text-red-400 mb-4 max-w-md truncate">
+                {this.state.error.message}
+              </p>
+            )}
+            <button
+              onClick={this.handleRetry}
+              className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-sm transition-colors flex items-center gap-2 cursor-pointer"
+            >
+              <RefreshCw className="size-4" />
+              Retry
+            </button>
+          </div>
+        </motion.div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

Adds React error boundaries across the frontend to catch rendering errors gracefully, preventing isolated component crashes from bringing down the entire page.

### Changes

- **`ErrorBoundary` component** (`apps/frontend/src/components/ErrorBoundary.tsx`): Class-based React error boundary with:
  - Fallback UI showing component name and error message
  - Retry button that resets the error state
  - Console error logging with optional component name for debugging
  - Optional custom `fallback` prop for section-specific UIs

- **Dashboard layout** (`apps/frontend/src/app/dashboard/layout.tsx`): Wrapped `{children}` with `<ErrorBoundary name="Page">` — prevents any page crash from taking down the entire dashboard shell (sidebar stays intact).

- **Overview page** (`apps/frontend/src/app/dashboard/page.tsx`): Wrapped each major section with its own error boundary:
  - `Stats Grid` — 4 stat cards
  - `Asset Balances` — settlement balance by asset + reserve health gauge
  - `Transaction Feed` — real-time transaction table

- **Treasury page** (`apps/frontend/src/app/dashboard/treasury/page.tsx`): Wrapped each major section:
  - `Mirror Assets` — asset list
  - `Burn History` — recent burn entries
  - `Liquidity Health` — health metrics bars

### Verification

- `pnpm --filter frontend build` — passes

Closes: #228