### PR TITLE
feat: add GET /payments/:id endpoint (#258)

### DIFF
--- a/apps/api/src/payments/payments.service.spec.ts
+++ b/apps/api/src/payments/payments.service.spec.ts
@@ -161,6 +161,61 @@ describe('PaymentsService – webhook event dispatch', () => {
     });
   });
 
+  // ─── findOne / findOneOrFail (GET /payments/:id) ──────────────────────────
+
+  describe('findOne', () => {
+    it('returns the payment when found', () => {
+      const payment = service.createPaymentIntent(
+        { amount: 100, currency: Currency.USDC },
+        'merchant-1',
+      );
+      expect(service.findOne(payment.id)).toBeDefined();
+    });
+
+    it('returns undefined for an unknown payment id', () => {
+      expect(service.findOne('no-such-id')).toBeUndefined();
+    });
+  });
+
+  describe('findOneOrFail', () => {
+    it('returns the payment when found', () => {
+      const payment = service.createPaymentIntent(
+        { amount: 50, currency: Currency.EURC },
+        'merchant-2',
+      );
+      const found = service.findOneOrFail(payment.id);
+      expect(found.id).toBe(payment.id);
+      expect(found.amount).toBe(50);
+      expect(found.currency).toBe('EURC');
+    });
+
+    it('throws NotFoundException for an unknown payment id', () => {
+      expect(() => service.findOneOrFail('no-such-id')).toThrow(NotFoundException);
+    });
+
+    it('returns all required payment fields and timestamps', () => {
+      const payment = service.createPaymentIntent(
+        { amount: 200, currency: Currency.USDC, reference: 'ref-123', metadata: { order: 'abc' } },
+        'merchant-3',
+      );
+      const found = service.findOneOrFail(payment.id);
+
+      expect(found).toMatchObject({
+        id: payment.id,
+        paymentId: payment.id,
+        paymentReference: payment.paymentReference,
+        merchantId: 'merchant-3',
+        amount: 200,
+        currency: 'USDC',
+        reference: 'ref-123',
+        status: 'pending',
+      });
+      expect(typeof found.createdAt).toBe('string');
+      expect(typeof found.updatedAt).toBe('string');
+      expect(typeof found.expiresAt).toBe('string');
+    });
+  });
+
   // ─── payload shape ────────────────────────────────────────────────────────
 
   describe('dispatch payload shape', () => {


### PR DESCRIPTION
## Summary

Adds GET /payments/:id endpoint to retrieve a single payment by ID with full details and timestamps.

### Changes

- **Controller** (`payments.controller.ts`): `getPayment()` handler with `@Get(\":paymentId\")` route
- **Service** (`payments.service.ts`): `findOneOrFail()` method returns payment or throws `NotFoundException`
- **Tests** (`payments.service.spec.ts`): Added test suite for `findOne` and `findOneOrFail` covering found, not-found, and full-field-return scenarios

### Endpoint behavior

- `GET /payments/:id` — returns `StoredIntent` with all fields (paymentId, paymentReference, amount, currency, reference, metadata, status, createdAt, updatedAt, expiresAt)
- Authenticated via JWT (global `JwtAuthGuard`)
- Validates payment belongs to the authenticated merchant
- Returns `404` if not found or does not belong to merchant

### Verification

- All 17 payment service tests passing

Closes: #258