### PR TITLE
feat(anchor-service): implement SEP-24 interactive deposit flow (#268)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,17 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.39.3",
+    "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
+    "jest": "^30.4.2",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
+    "ts-jest": "^29.4.11",
     "turbo": "^1.13.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1"

--- a/packages/anchor-service/src/anchor.service.spec.ts
+++ b/packages/anchor-service/src/anchor.service.spec.ts
@@ -140,6 +140,32 @@ describe('AnchorService.fetchTransactionHistory', () => {
   });
 });
 
+describe('AnchorService SEP-24 deposits', () => {
+  it('creates an interactive deposit and exposes its polling status', async () => {
+    const service = new AnchorService();
+
+    const result = await service.createSep24Deposit('USDC', '100', 'account-123');
+
+    expect(result.success).toBe(true);
+    expect(result.interactiveUrl).toContain('/deposit/interactive');
+    expect(result.interactiveUrl).toContain('asset_code=USDC');
+    expect(result.interactiveUrl).toContain('amount=100');
+    expect(result.interactiveUrl).toContain('account=account-123');
+    expect(result.status).toBe('pending');
+
+    expect(result.transactionId).toBeDefined();
+
+    const polled = service.pollSep24DepositStatus(result.transactionId ?? '');
+
+    expect(polled).toMatchObject({
+      transactionId: result.transactionId,
+      status: 'pending',
+      assetCode: 'USDC',
+      amount: '100',
+    });
+  });
+});
+
 describe('AnchorService SEP-24 withdrawals', () => {
   it('creates an interactive withdrawal and exposes its polling status', async () => {
     const service = new AnchorService();

--- a/packages/anchor-service/src/anchor.service.ts
+++ b/packages/anchor-service/src/anchor.service.ts
@@ -25,6 +25,8 @@ import type { PaymentStatusResponse } from './interfaces/payment-status.interfac
 import type {
   DepositParams,
   DepositResponse,
+  Sep24Transaction,
+  Sep24DepositResponse,
   Sep24WithdrawalResponse,
 } from './interfaces/sep24.interface';
 import type { SwapParams, SwapResult } from './interfaces/swap.interface';
@@ -881,7 +883,44 @@ export class AnchorService {
   // SEP-24 Deposit Flow
   // ---------------------------------------------------------------------------
 
-  async createSep24Deposit(params: DepositParams): Promise<DepositResponse> {
+  async createSep24Deposit(
+    assetCode: string,
+    amount: string,
+    accountId: string,
+  ): Promise<Sep24DepositResponse>;
+  async createSep24Deposit(params: DepositParams): Promise<DepositResponse>;
+  async createSep24Deposit(
+    assetCodeOrParams: string | DepositParams,
+    amount?: string,
+    accountId?: string,
+  ): Promise<Sep24DepositResponse | DepositResponse> {
+    if (typeof assetCodeOrParams === 'object') {
+      return this.executeSep24Deposit(assetCodeOrParams);
+    }
+
+    const params: DepositParams = {
+      anchorUrl: process.env.ANCHOR_URL ?? 'https://anchor.example.com',
+      account: accountId!,
+      assetCode: assetCodeOrParams,
+      amount,
+    };
+
+    const deposit = await this.executeSep24Deposit(params);
+
+    return {
+      success: deposit.success,
+      transactionId: deposit.transactionId,
+      interactiveUrl: deposit.interactiveUrl,
+      error: deposit.error,
+      amount: deposit.amount,
+      assetCode: deposit.assetCode,
+      status: deposit.status,
+      createdAt: deposit.createdAt,
+      updatedAt: deposit.updatedAt,
+    };
+  }
+
+  private async executeSep24Deposit(params: DepositParams): Promise<DepositResponse> {
     const transactionId = `sep24_${crypto.randomUUID().split('-').join('').slice(0, 16)}`;
 
     try {
@@ -937,6 +976,25 @@ export class AnchorService {
         updatedAt: record.updatedAt,
       };
     }
+  }
+
+  pollSep24DepositStatus(transactionId: string): Sep24Transaction | undefined {
+    const deposit = this.sep24Deposits.get(transactionId);
+    if (!deposit) {
+      return undefined;
+    }
+
+    return {
+      transactionId: deposit.transactionId,
+      account: deposit.account,
+      assetCode: deposit.assetCode,
+      amount: deposit.amount,
+      status: deposit.status,
+      interactiveUrl: deposit.interactiveUrl,
+      error: deposit.error,
+      createdAt: deposit.createdAt,
+      updatedAt: deposit.updatedAt,
+    };
   }
 
   getSep24Deposit(transactionId: string): Sep24DepositRecord | undefined {

--- a/packages/anchor-service/src/index.ts
+++ b/packages/anchor-service/src/index.ts
@@ -35,6 +35,8 @@ export type { AnchorAsset, AnchorConfig } from './interfaces/anchor-asset.interf
 export type {
   DepositParams,
   DepositResponse,
+  Sep24Transaction,
+  Sep24DepositResponse,
   Sep24WithdrawalResponse,
 } from './interfaces/sep24.interface';
 export type { SwapParams, SwapResult, StellarAsset } from './interfaces/swap.interface';

--- a/packages/anchor-service/src/interfaces/sep24.interface.ts
+++ b/packages/anchor-service/src/interfaces/sep24.interface.ts
@@ -35,3 +35,27 @@ export interface Sep24WithdrawalResponse {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface Sep24Transaction {
+  transactionId: string;
+  account: string;
+  assetCode: string;
+  amount?: string;
+  status: 'pending' | 'incomplete' | 'completed' | 'failed';
+  interactiveUrl?: string;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Sep24DepositResponse {
+  success: boolean;
+  transactionId?: string;
+  interactiveUrl?: string;
+  error?: string;
+  amount?: string;
+  assetCode?: string;
+  status?: 'pending' | 'incomplete' | 'completed' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.3
         version: 9.39.4
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.56.1
         version: 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
@@ -29,12 +32,18 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       lint-staged:
         specifier: ^16.2.7
         version: 16.4.0
       prettier:
         specifier: ^3.8.1
         version: 3.9.0
+      ts-jest:
+        specifier: ^29.4.11
+        version: 29.4.11(@babel/core@7.29.7(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)))(typescript@5.9.3)
       turbo:
         specifier: ^1.13.4
         version: 1.13.4


### PR DESCRIPTION
## Summary

Implements the SEP-24 interactive deposit flow in anchor-service (issue #268).

## Changes

- **sep24.interface.ts**: Added `Sep24Transaction` and `Sep24DepositResponse` interfaces
- **anchor.service.ts**: Added `createSep24Deposit(assetCode, amount, accountId)` convenience overload + `pollSep24DepositStatus(id)` method
- **index.ts**: Exported new interfaces
- **anchor.service.spec.ts**: Added deposit test (matching existing withdrawal pattern)

### New public API

```ts
const deposit = await service.createSep24Deposit(USDC, 100, account-123);
const status = service.pollSep24DepositStatus(deposit.transactionId);
```

closes: #268 