### PR TITLE
feat(frontend): responsive mobile dashboard navigation (#236)

### DIFF
--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion } from 'motion/react';
+import { motion, AnimatePresence } from 'motion/react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -18,7 +18,7 @@ import {
   X,
   ChevronRight,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -36,17 +36,116 @@ const navigation = [
   { name: 'Audit Logs', href: '/dashboard/audit-logs', icon: FileText },
 ];
 
+function SidebarContent({ onNavClick }: { onNavClick?: () => void }) {
+  const pathname = usePathname();
+
+  return (
+    <>
+      <div className="h-16 flex items-center justify-between px-6 border-b border-white/5 shrink-0">
+        <Link
+          href="/"
+          onClick={onNavClick}
+          className="font-medium text-lg hover:text-neutral-400 transition-colors cursor-pointer"
+        >
+          StellarPay Rails
+        </Link>
+        {onNavClick && (
+          <button
+            onClick={onNavClick}
+            className="flex items-center justify-center w-10 h-10 hover:bg-white/5 rounded-lg transition-colors cursor-pointer lg:hidden"
+            aria-label="Close navigation menu"
+          >
+            <X className="size-5" />
+          </button>
+        )}
+      </div>
+
+      <nav className="flex-1 px-3 py-4 overflow-y-auto">
+        <div className="space-y-1">
+          {navigation.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.name}
+                href={item.href}
+                onClick={onNavClick}
+                className="block cursor-pointer"
+              >
+                <motion.div
+                  className={`flex items-center gap-3 px-3 py-3 rounded-lg transition-all min-h-11 ${
+                    isActive
+                      ? 'bg-white/10 text-white'
+                      : 'text-neutral-400 hover:text-white hover:bg-white/5'
+                  }`}
+                  whileHover={{ x: 4 }}
+                  whileTap={{ scale: 0.98 }}
+                >
+                  <item.icon className="size-5 flex-shrink-0" />
+                  <span className="text-sm font-medium">{item.name}</span>
+                  {isActive && (
+                    <motion.div layoutId="activeIndicator" className="ml-auto">
+                      <ChevronRight className="size-4" />
+                    </motion.div>
+                  )}
+                </motion.div>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      <div className="p-4 border-t border-white/5 shrink-0">
+        <div className="text-xs text-neutral-500">
+          <div className="mb-1">
+            API Status: <span className="text-green-400">Operational</span>
+          </div>
+          <div>
+            Environment: <span className="text-yellow-400">Development</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const { isAuthenticated, loading } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
   useEffect(() => {
     if (!loading && !isAuthenticated) {
       router.replace('/login');
     }
   }, [isAuthenticated, loading, router]);
+
+  useEffect(() => {
+    closeSidebar();
+  }, [pathname, closeSidebar]);
+
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && sidebarOpen) {
+        setSidebarOpen(false);
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [sidebarOpen]);
 
   if (loading) {
     return null;
@@ -58,85 +157,50 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="min-h-screen bg-black text-white">
-      {/* Mobile menu button */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-xl border-b border-white/5 px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="font-medium">StellarPay Rails</div>
+      {/* Mobile header */}
+      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-xl border-b border-white/5 px-4">
+        <div className="flex items-center justify-between h-16">
           <button
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-            className="p-2 hover:bg-white/5 rounded-lg transition-colors cursor-pointer"
+            onClick={() => setSidebarOpen(true)}
+            className="flex items-center justify-center w-10 h-10 hover:bg-white/5 rounded-lg transition-colors cursor-pointer"
+            aria-label="Open navigation menu"
           >
-            {sidebarOpen ? <X className="size-5" /> : <Menu className="size-5" />}
+            <Menu className="size-5" />
           </button>
+          <span className="font-medium">StellarPay Rails</span>
+          <div className="w-10" />
         </div>
       </div>
 
-      {/* Sidebar */}
-      <motion.aside
-        className={`fixed top-0 left-0 bottom-0 w-64 bg-black border-r border-white/5 flex flex-col z-40 ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        } lg:translate-x-0 transition-transform duration-300`}
-        initial={{ x: -256 }}
-        animate={{ x: 0 }}
-        transition={{ duration: 0.3 }}
-      >
-        {/* Logo */}
-        <div className="h-16 flex items-center px-6 border-b border-white/5">
-          <Link
-            href="/"
-            className="font-medium text-lg hover:text-neutral-400 transition-colors cursor-pointer"
-          >
-            StellarPay Rails
-          </Link>
-        </div>
+      {/* Desktop sidebar */}
+      <aside className="hidden lg:flex fixed top-0 left-0 bottom-0 w-64 bg-black border-r border-white/5 flex-col z-40">
+        <SidebarContent />
+      </aside>
 
-        {/* Navigation */}
-        <nav className="flex-1 px-3 py-4 overflow-y-auto">
-          <div className="space-y-1">
-            {navigation.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  onClick={() => setSidebarOpen(false)}
-                  className="block cursor-pointer"
-                >
-                  <motion.div
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-all ${
-                      isActive
-                        ? 'bg-white/10 text-white'
-                        : 'text-neutral-400 hover:text-white hover:bg-white/5'
-                    }`}
-                    whileHover={{ x: 4 }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <item.icon className="size-5 flex-shrink-0" />
-                    <span className="text-sm font-medium">{item.name}</span>
-                    {isActive && (
-                      <motion.div layoutId="activeIndicator" className="ml-auto">
-                        <ChevronRight className="size-4" />
-                      </motion.div>
-                    )}
-                  </motion.div>
-                </Link>
-              );
-            })}
-          </div>
-        </nav>
-
-        {/* Footer */}
-        <div className="p-4 border-t border-white/5">
-          <div className="text-xs text-neutral-500">
-            <div className="mb-1">
-              API Status: <span className="text-green-400">Operational</span>
-            </div>
-            <div>
-              Environment: <span className="text-yellow-400">Development</span>
-            </div>
-          </div>
-        </div>
-      </motion.aside>
+      {/* Mobile drawer */}
+      <AnimatePresence>
+        {sidebarOpen && (
+          <>
+            <motion.div
+              className="lg:hidden fixed inset-0 bg-black/80 backdrop-blur-sm z-40"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={closeSidebar}
+              aria-hidden="true"
+            />
+            <motion.aside
+              className="lg:hidden fixed top-0 left-0 bottom-0 w-64 max-w-[85vw] bg-black border-r border-white/5 flex flex-col z-50"
+              initial={{ x: '-100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '-100%' }}
+              transition={{ type: 'spring', damping: 28, stiffness: 300 }}
+            >
+              <SidebarContent onNavClick={closeSidebar} />
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
 
       {/* Main content */}
       <div className="lg:pl-64 pt-16 lg:pt-0">
@@ -146,14 +210,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           </ErrorBoundary>
         </main>
       </div>
-
-      {/* Mobile overlay */}
-      {sidebarOpen && (
-        <div
-          className="lg:hidden fixed inset-0 bg-black/80 backdrop-blur-sm z-30"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Makes the dashboard sidebar navigation responsive on mobile (issue #236).

## Changes

- Extracted `SidebarContent` as a reusable component shared between mobile drawer and desktop sidebar
- **Mobile** (< `lg` breakpoint): Hamburgermenu → slide-out drawer with spring animation (`motion` + `AnimatePresence`)
- **Desktop** (≥ `lg`): Static sidebar always visible
- Increased nav item touch targets to `min-h-11` (44px, Apple HIG compliant)
- Body scroll lock when sidebar is open
- Escape key to close sidebar
- Auto-close on route change
- `max-w-[85vw]` on drawer for 320px viewport support
- `aria-label` on menu buttons for accessibility
- Close button (X) in drawer header alongside the logo

### Breakpoint behavior

| Viewport | Behavior |
|---|---|
| ≥ 1024px | Static sidebar always visible |
| 768px | Slide-out drawer with overlay |
| 320px | Drawer at 85vw width with cozy touch targets |

closes: #236