### PR TITLE
Add Subscription model to Prisma schema

### DIFF
--- a/packages/database/migrations/schema.prisma
+++ b/packages/database/migrations/schema.prisma
@@ -52,6 +52,7 @@ model Merchant {
   apiKeys          ApiKey[]
   auditLogs        AuditLog[]
   customers        Customer[]
+  subscriptions    Subscription[]
   users            User[]
 
   @@map("merchants")
@@ -84,6 +85,8 @@ model Customer {
   updatedAt   DateTime       @updatedAt @map("updated_at")
 
   merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+
+  subscriptions Subscription[]
 
   @@index([merchantId, status])
   @@map("customers")
@@ -188,4 +191,42 @@ model AuditLog {
 
   @@index([merchantId])
   @@map("audit_logs")
+}
+
+enum SubscriptionInterval {
+  DAILY
+  WEEKLY
+  MONTHLY
+  YEARLY
+
+  @@map("subscription_interval")
+}
+
+enum SubscriptionStatus {
+  ACTIVE
+  PAUSED
+  CANCELLED
+  EXPIRED
+
+  @@map("subscription_status")
+}
+
+model Subscription {
+  id         String               @id @default(uuid()) @db.Uuid
+  merchantId String               @map("merchant_id") @db.Uuid
+  customerId String               @map("customer_id") @db.Uuid
+  planName   String               @map("plan_name")
+  amount     Decimal              @db.Decimal(18, 2)
+  currency   String               @db.VarChar(3)
+  interval   SubscriptionInterval
+  status     SubscriptionStatus
+  createdAt  DateTime             @default(now()) @map("created_at")
+  updatedAt  DateTime             @updatedAt @map("updated_at")
+
+  merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+  customer Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+
+  @@index([merchantId, status])
+  @@index([customerId])
+  @@map("subscriptions")
 }


### PR DESCRIPTION
Closes #242

Adds a Subscription model for recurring payment plans with:
- `SubscriptionInterval` enum: DAILY, WEEKLY, MONTHLY, YEARLY
- `SubscriptionStatus` enum: ACTIVE, PAUSED, CANCELLED, EXPIRED
- Relations to Merchant and Customer models
- Indexes on merchantId+status and customerId