### PR TITLE
Add EscrowTransaction model to Prisma schema

### DIFF
--- a/packages/database/migrations/schema.prisma
+++ b/packages/database/migrations/schema.prisma
@@ -32,6 +32,15 @@ enum TreasuryWalletType {
   COLD
 }
 
+enum EscrowStatus {
+  PENDING
+  FUNDED
+  RELEASED
+  CANCELLED
+  REFUNDED
+  DISPUTED
+}
+
 enum UserRole {
   ADMIN
   VIEWER
@@ -53,6 +62,7 @@ model Merchant {
   auditLogs        AuditLog[]
   customers        Customer[]
   users            User[]
+  escrows          EscrowTransaction[]
 
   @@map("merchants")
 }
@@ -188,4 +198,22 @@ model AuditLog {
 
   @@index([merchantId])
   @@map("audit_logs")
+}
+
+model EscrowTransaction {
+  id         String       @id @default(uuid()) @db.Uuid
+  merchantId String       @map("merchant_id") @db.Uuid
+  sender     String
+  receiver   String
+  amount     Decimal      @db.Decimal(18, 2)
+  assetCode  String       @map("asset_code") @db.VarChar(10)
+  milestones Json
+  status     EscrowStatus @default(PENDING)
+  createdAt  DateTime     @default(now()) @map("created_at")
+  updatedAt  DateTime     @updatedAt @map("updated_at")
+
+  merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+
+  @@index([merchantId, status])
+  @@map("escrow_transactions")
 }


### PR DESCRIPTION
Closes #241

Adds an EscrowTransaction model for the escrow smart contract data.

**Changes:**
- Added `EscrowStatus` enum: PENDING, FUNDED, RELEASED, CANCELLED, REFUNDED, DISPUTED
- Added `EscrowTransaction` model with fields: id, merchantId, sender, receiver, amount, assetCode, milestones (Json), status, createdAt, updatedAt
- Added `escrows` relation on Merchant
- Indexed on (merchantId, status)