### PR TITLE
Add Redis connection health check indicator

### DIFF
--- a/apps/api/src/health/indicators/redis.health.ts
+++ b/apps/api/src/health/indicators/redis.health.ts
@@ -1,21 +1,41 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import Redis from 'ioredis';
 
 @Injectable()
 export class RedisHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(RedisHealthIndicator.name);
+
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    let client: Redis | null = null;
+
     try {
-      // TODO: Implement actual Redis connectivity check
-      // When Redis service is implemented, inject it here and verify connection
-      // Example:
-      // await this.redisClient.ping();
+      client = new Redis({
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        maxRetriesPerRequest: 1,
+        retryStrategy: null,
+        lazyConnect: true,
+      });
+
+      await client.connect();
+      const response = await client.ping();
+
+      if (response !== 'PONG') {
+        throw new Error(`Unexpected Redis ping response: ${response}`);
+      }
 
       return this.getStatus(key, true);
-    } catch {
+    } catch (error) {
+      this.logger.error(`Redis health check failed: ${(error as Error).message}`);
       throw new HealthCheckError(
         'Redis check failed',
         this.getStatus(key, false, { message: 'Redis connection unavailable' }),
       );
+    } finally {
+      if (client) {
+        client.disconnect();
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #274

Implement the Redis health indicator with actual Redis PING command.

**Changes:**
- Replaced placeholder with real Redis connectivity check using ioredis
- Creates Redis client with lazyConnect, calls `ping()`, validates response is `PONG`
- Returns healthy only on successful PONG
- Logs connection errors via Logger for debugging
- Disconnects client in `finally` block to clean up resources