### PR TITLE
Add SubscriptionInvoice model to Prisma schema

### DIFF
--- a/packages/database/migrations/schema.prisma
+++ b/packages/database/migrations/schema.prisma
@@ -233,10 +233,40 @@ model Subscription {
   createdAt  DateTime             @default(now()) @map("created_at")
   updatedAt  DateTime             @updatedAt @map("updated_at")
 
-  merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
-  customer Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  merchant Merchant               @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+  customer Customer               @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  invoices SubscriptionInvoice[]
 
   @@index([merchantId, status])
   @@index([customerId])
   @@map("subscriptions")
+}
+
+enum SubscriptionInvoiceStatus {
+  PENDING
+  PAID
+  OVERDUE
+  CANCELLED
+  REFUNDED
+
+  @@map("subscription_invoice_status")
+}
+
+model SubscriptionInvoice {
+  id               String                    @id @default(uuid()) @db.Uuid
+  subscriptionId   String                    @map("subscription_id") @db.Uuid
+  invoiceNumber    String                    @unique @map("invoice_number")
+  amount           Decimal                   @db.Decimal(18, 2)
+  currency         String                    @db.VarChar(3)
+  dueDate          DateTime                  @map("due_date")
+  paidAt           DateTime?                 @map("paid_at")
+  status           SubscriptionInvoiceStatus @default(PENDING)
+  createdAt        DateTime                  @default(now()) @map("created_at")
+  updatedAt        DateTime                  @updatedAt @map("updated_at")
+
+  subscription Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+
+  @@index([subscriptionId, status])
+  @@index([status])
+  @@map("subscription_invoices")
 }


### PR DESCRIPTION
Closes #243

Adds a SubscriptionInvoice model for billing records.

**Changes:**
- Added `SubscriptionInvoiceStatus` enum: PENDING, PAID, OVERDUE, CANCELLED, REFUNDED
- Added `SubscriptionInvoice` model with fields: id, subscriptionId, invoiceNumber (unique), amount, currency, dueDate, paidAt (nullable), status, createdAt, updatedAt
- Added `invoices` relation on the Subscription model
- Indexed on (subscriptionId, status) and (status)