### PR TITLE
feat: add Payout model to Prisma schema (#244)

### DIFF
--- a/packages/database/migrations/schema.prisma
+++ b/packages/database/migrations/schema.prisma
@@ -41,6 +41,16 @@ enum EscrowStatus {
   DISPUTED
 }
 
+enum PayoutStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+  CANCELLED
+
+  @@map("payout_status")
+}
+
 enum UserRole {
   ADMIN
   VIEWER
@@ -64,6 +74,7 @@ model Merchant {
   subscriptions    Subscription[]
   users            User[]
   escrows          EscrowTransaction[]
+  payouts          Payout[]
 
   @@map("merchants")
 }
@@ -171,6 +182,24 @@ model WebhookEvent {
   @@map("webhook_events")
 }
 
+model Payout {
+  id                 String       @id @default(uuid()) @db.Uuid
+  merchantId         String       @map("merchant_id") @db.Uuid
+  amount             Decimal      @db.Decimal(18, 2)
+  currency           String       @db.VarChar(3)
+  destinationAddress String       @map("destination_address")
+  status             PayoutStatus @default(PENDING)
+  txHash             String?      @map("tx_hash")
+  errorMessage       String?      @map("error_message")
+  createdAt          DateTime     @default(now()) @map("created_at")
+  updatedAt          DateTime     @updatedAt @map("updated_at")
+
+  merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+
+  @@index([merchantId, status])
+  @@map("payouts")
+}
+
 model ApiKey {
   id         String   @id @default(uuid()) @db.Uuid
   merchantId String   @map("merchant_id") @db.Uuid
@@ -239,4 +268,22 @@ model Subscription {
   @@index([merchantId, status])
   @@index([customerId])
   @@map("subscriptions")
+}
+
+model EscrowTransaction {
+  id         String       @id @default(uuid()) @db.Uuid
+  merchantId String       @map("merchant_id") @db.Uuid
+  sender     String
+  receiver   String
+  amount     Decimal      @db.Decimal(18, 2)
+  assetCode  String       @map("asset_code") @db.VarChar(10)
+  milestones Json
+  status     EscrowStatus @default(PENDING)
+  createdAt  DateTime     @default(now()) @map("created_at")
+  updatedAt  DateTime     @updatedAt @map("updated_at")
+
+  merchant Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+
+  @@index([merchantId, status])
+  @@map("escrow_transactions")
 }


### PR DESCRIPTION
Closes #244 

- Added `PayoutStatus` enum: PENDING, PROCESSING, COMPLETED, FAILED, CANCELLED
- Added `Payout` model with fields: id, merchantId, amount, currency, destinationAddress, status, txHash (nullable), errorMessage (nullable), timestamps
- Added `payouts` relation to Merchant
- Also restored missing `EscrowTransaction` model that was accidentally dropped during Subscription schema merge — the Merchant already had `escrows EscrowTransaction[]` relation but the model was missing, causing validation errors.

Conventions followed: `@db.Uuid`, `@map("snake_case")`, `@@map("plural_snake_case")`, Cascade deletes, index on (merchantId, status).